### PR TITLE
Add multilingual home metadata settings and migration (1.7.1)

### DIFF
--- a/beesblog.php
+++ b/beesblog.php
@@ -87,7 +87,7 @@ class BeesBlog extends Module
     {
         $this->name = 'beesblog';
         $this->tab = 'front_office_features';
-        $this->version = '1.7.0';
+        $this->version = '1.7.1';
         $this->author = 'thirty bees';
         $this->tb_min_version = '1.0.0';
         $this->tb_versions_compliancy = '> 1.0.0';
@@ -130,9 +130,9 @@ class BeesBlog extends Module
 
         Configuration::updateGlobalValue(static::SHOW_NO_IMAGE, false);
         Configuration::updateGlobalValue(static::SHOW_CATEGORY_IMAGE, false);
-        Configuration::updateGlobalValue(static::HOME_TITLE, 'Bees blog title');
-        Configuration::updateGlobalValue(static::HOME_KEYWORDS, 'thirty bees blog,thirty bees');
-        Configuration::updateGlobalValue(static::HOME_DESCRIPTION, 'The beesiest blog for thirty bees');
+        Configuration::updateValue(static::HOME_TITLE, $this->getLocalizedConfigurationValues('Bees blog title'));
+        Configuration::updateValue(static::HOME_KEYWORDS, $this->getLocalizedConfigurationValues('thirty bees blog,thirty bees'));
+        Configuration::updateValue(static::HOME_DESCRIPTION, $this->getLocalizedConfigurationValues('The beesiest blog for thirty bees'));
 
         if ($createTables) {
             if (!(BeesBlogPost::createDatabase()
@@ -715,6 +715,7 @@ class BeesBlog extends Module
                     'name'     => static::HOME_TITLE,
                     'size'     => 70,
                     'required' => true,
+                    'lang'     => true,
                 ],
                 [
                     'type'     => 'textarea',
@@ -723,6 +724,15 @@ class BeesBlog extends Module
                     'rows'     => 7,
                     'cols'     => 66,
                     'required' => true,
+                    'lang'     => true,
+                ],
+                [
+                    'type'     => 'text',
+                    'label'    => $this->l('Meta keywords'),
+                    'name'     => static::HOME_KEYWORDS,
+                    'size'     => 70,
+                    'required' => false,
+                    'lang'     => true,
                 ],
                 [
                     'type'     => 'text',
@@ -909,7 +919,7 @@ class BeesBlog extends Module
      */
     protected function getFormValues()
     {
-        return Configuration::getMultiple(
+        $values = Configuration::getMultiple(
             [
                 static::POSTS_PER_PAGE,
                 static::SHOW_AUTHOR,
@@ -918,15 +928,39 @@ class BeesBlog extends Module
                 static::AUTHOR_STYLE,
                 static::MAIN_URL_KEY,
                 static::USE_HTML,
-                static::HOME_TITLE,
-                static::HOME_KEYWORDS,
-                static::HOME_DESCRIPTION,
-                static::SHOW_POST_COUNT,
                 static::SHOW_POST_COUNT,
                 static::SHOW_CATEGORY_IMAGE,
                 static::SHOW_NO_IMAGE,
             ]
         );
+
+        $values[static::HOME_TITLE] = [];
+        $values[static::HOME_KEYWORDS] = [];
+        $values[static::HOME_DESCRIPTION] = [];
+
+        foreach (Language::getLanguages(false) as $language) {
+            $languageId = (int) $language['id_lang'];
+            $values[static::HOME_TITLE][$languageId] = Configuration::get(static::HOME_TITLE, $languageId);
+            $values[static::HOME_KEYWORDS][$languageId] = Configuration::get(static::HOME_KEYWORDS, $languageId);
+            $values[static::HOME_DESCRIPTION][$languageId] = Configuration::get(static::HOME_DESCRIPTION, $languageId);
+        }
+
+        return $values;
+    }
+
+    /**
+     * @param string $defaultValue
+     *
+     * @return array
+     */
+    protected function getLocalizedConfigurationValues($defaultValue)
+    {
+        $values = [];
+        foreach (Language::getLanguages(false) as $language) {
+            $values[(int) $language['id_lang']] = $defaultValue;
+        }
+
+        return $values;
     }
 
     /**

--- a/controllers/front/category.php
+++ b/controllers/front/category.php
@@ -121,10 +121,12 @@ class BeesBlogCategoryModuleFrontController extends ModuleFrontController
         // Make a fake category if the category ID has not been given
         $category = new BeesBlogCategory();
         $category->active = true;
-        $category->title = Configuration::get(BeesBlog::HOME_TITLE);
-        $category->meta_title = Configuration::get(BeesBlog::HOME_TITLE);
-        $category->description = Configuration::get(BeesBlog::HOME_DESCRIPTION);
-        $category->meta_description = Configuration::get(BeesBlog::HOME_DESCRIPTION);
+        $languageId = (int) $this->context->language->id;
+        $category->title = Configuration::get(BeesBlog::HOME_TITLE, $languageId);
+        $category->meta_title = Configuration::get(BeesBlog::HOME_TITLE, $languageId);
+        $category->description = Configuration::get(BeesBlog::HOME_DESCRIPTION, $languageId);
+        $category->meta_description = Configuration::get(BeesBlog::HOME_DESCRIPTION, $languageId);
+        $category->meta_keywords = Configuration::get(BeesBlog::HOME_KEYWORDS, $languageId);
         return $category;
     }
 

--- a/upgrade/upgrade-1.7.1.php
+++ b/upgrade/upgrade-1.7.1.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyright (C) 2017-2024 thirty bees
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@thirtybees.com so we can send you a copy immediately.
+ *
+ * @author    thirty bees <modules@thirtybees.com>
+ * @copyright 2017-2024 thirty bees
+ * @license   Academic Free License (AFL 3.0)
+ */
+
+if (!defined('_TB_VERSION_')) {
+    exit;
+}
+
+/**
+ * @return bool
+ * @throws PrestaShopException
+ */
+function upgrade_module_1_7_1()
+{
+    $languages = Language::getLanguages(false);
+    $keys = [
+        'BEESBLOG_META_TITLE',
+        'BEESBLOG_META_KEYWORDS',
+        'BEESBLOG_META_DESCRIPTION',
+    ];
+
+    foreach ($keys as $key) {
+        $currentValue = Configuration::get($key);
+        if (is_array($currentValue)) {
+            $values = $currentValue;
+        } else {
+            $values = [];
+            foreach ($languages as $language) {
+                $values[(int) $language['id_lang']] = (string) $currentValue;
+            }
+        }
+
+        if (!Configuration::updateValue($key, $values)) {
+            return false;
+        }
+    }
+
+    return true;
+}


### PR DESCRIPTION
### Motivation
- Enable multilanguage support for the blog module's home meta data so each shop language can have its own meta title, description and keywords.
- Provide a safe upgrade path to migrate existing single-value settings to per-language configuration values.

### Description
- Store home metadata as localized configuration values by adding `getLocalizedConfigurationValues()` and using `Configuration::updateValue()` with per-language arrays during installation, and bump module `version` to `1.7.1`.
- Expose meta title, meta description and meta keywords as multilingual fields in the settings form by marking the inputs with `'lang' => true` and returning localized values from `getFormValues()` using `Configuration::get(..., $languageId)`.
- Load localized home metadata for the blog home placeholder in `controllers/front/category.php` using `Configuration::get(<KEY>, $languageId)` and populate `meta_keywords` for the fake category.
- Add an upgrade script `upgrade/upgrade-1.7.1.php` that migrates existing `BEESBLOG_META_TITLE`, `BEESBLOG_META_KEYWORDS` and `BEESBLOG_META_DESCRIPTION` values into per-language arrays for all installed languages.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a95a1ae20832da62f678e069acd5d)