### PR TITLE
Make beesblog multistore-aware (shop associations, migration, queries and BO support)

### DIFF
--- a/beesblog.php
+++ b/beesblog.php
@@ -87,7 +87,7 @@ class BeesBlog extends Module
     {
         $this->name = 'beesblog';
         $this->tab = 'front_office_features';
-        $this->version = '1.7.0';
+        $this->version = '1.7.1';
         $this->author = 'thirty bees';
         $this->tb_min_version = '1.0.0';
         $this->tb_versions_compliancy = '> 1.0.0';
@@ -486,6 +486,7 @@ class BeesBlog extends Module
 
         // Blog posts
         $results = (new PrestaShopCollection('BeesBlogModule\\BeesBlogPost', $langId))
+            ->sqlJoin(Shop::addSqlAssociation(BeesBlogPost::TABLE, 'a'))
             ->where('active', '=', 1)
             ->getResults();
         if ($results) {
@@ -504,6 +505,7 @@ class BeesBlog extends Module
 
         // Categories
         $results = (new PrestaShopCollection('BeesBlogModule\\BeesBlogCategory', $langId))
+            ->sqlJoin(Shop::addSqlAssociation(BeesBlogCategory::TABLE, 'a'))
             ->where('active', '=', 1)
             ->getResults();
 

--- a/classes/BeesBlogCategory.php
+++ b/classes/BeesBlogCategory.php
@@ -27,6 +27,7 @@ use DbQuery;
 use ObjectModel;
 use PrestaShopDatabaseException;
 use PrestaShopException;
+use Shop;
 
 if (!defined('_TB_VERSION_')) {
     exit;
@@ -206,6 +207,7 @@ class BeesBlogCategory extends ObjectModel
         $postCollection = new Collection('BeesBlogModule\\BeesBlogPost', $idLang);
         $postCollection->setPageSize($limit);
         $postCollection->setPageNumber($page);
+        $postCollection->sqlJoin(Shop::addSqlAssociation(BeesBlogPost::TABLE, 'a'));
         $postCollection->orderBy('published', 'desc');
         $postCollection->where('published', '<=', date('Y-m-d H:i:s'));
         $postCollection->where('id_category', '=', $this->id);
@@ -240,6 +242,7 @@ class BeesBlogCategory extends ObjectModel
         $categoryCollection = new Collection('BeesBlogModule\\BeesBlogCategory', $idLang);
         $categoryCollection->setPageSize($limit);
         $categoryCollection->setPageNumber($page);
+        $categoryCollection->sqlJoin(Shop::addSqlAssociation(static::TABLE, 'a'));
 
         if ($count) {
             return $categoryCollection->count();
@@ -264,6 +267,7 @@ class BeesBlogCategory extends ObjectModel
         }
 
         $categoryCollection = new Collection('BeesBlogModule\\BeesBlogCategory', $idLang);
+        $categoryCollection->sqlJoin(Shop::addSqlAssociation(static::TABLE, 'a'));
         $categoryCollection->where('id_parent', '=', 0);
 
         /** @var BeesBlogCategory|false $ret */
@@ -373,16 +377,18 @@ class BeesBlogCategory extends ObjectModel
      */
     public static function getNameById($id, $id_lang = null)
     {
-        if (empty($idLang)) {
-            $idLang = (int) Context::getContext()->language->id;
+        if (empty($id_lang)) {
+            $id_lang = (int) Context::getContext()->language->id;
         }
+        $idShop = (int) Context::getContext()->shop->id;
 
         $sql = new DbQuery();
         $sql->select('sbcl.`title`');
         $sql->from(static::TABLE, 'sbc');
         $sql->innerJoin(static::LANG_TABLE, 'sbcl', 'sbc.`'.static::PRIMARY.'` = sbcl.`'.static::PRIMARY.'`');
         $sql->innerJoin(static::SHOP_TABLE, 'sbcs', 'sbc.`'.static::PRIMARY.'` = sbcs.`'.static::PRIMARY.'`');
-        $sql->where('sbcl.`id_lang` = '.(int) $idLang);
+        $sql->where('sbcl.`id_lang` = '.(int) $id_lang);
+        $sql->where('sbcs.`id_shop` = '.(int) $idShop);
         $sql->where('sbcl.`'.static::PRIMARY.'` = \''.pSQL($id).'\'');
 
         return Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql);

--- a/classes/BeesBlogPost.php
+++ b/classes/BeesBlogPost.php
@@ -28,6 +28,7 @@ use DbQuery;
 use ObjectModel;
 use PrestaShopDatabaseException;
 use PrestaShopException;
+use Shop;
 
 if (!defined('_TB_VERSION_')) {
     exit;
@@ -264,6 +265,7 @@ class BeesBlogPost extends ObjectModel
         $postCollection = new Collection('BeesBlogModule\\BeesBlogPost', $idLang);
         $postCollection->setPageSize($limit);
         $postCollection->setPageNumber($page);
+        $postCollection->sqlJoin(Shop::addSqlAssociation(static::TABLE, 'a'));
         $postCollection->orderBy('published', 'desc');
         $postCollection->where('published', '<=', date('Y-m-d H:i:s'));
         $postCollection->where('active', '=', '1');
@@ -312,6 +314,7 @@ class BeesBlogPost extends ObjectModel
         $postCollection = new Collection('BeesBlogModule\\BeesBlogPost', $idLang);
         $postCollection->setPageSize($limit);
         $postCollection->setPageNumber($page);
+        $postCollection->sqlJoin(Shop::addSqlAssociation(static::TABLE, 'a'));
         $postCollection->orderBy('viewed', 'desc');
         $postCollection->where('published', '<=', date('Y-m-d H:i:s'));
         $postCollection->sqlWhere('lang_active = \'1\'');
@@ -368,7 +371,8 @@ class BeesBlogPost extends ObjectModel
     {
         $sql = new DbQuery();
         $sql->select('`'.self::PRIMARY.'`');
-        $sql->from(self::TABLE);
+        $sql->from(self::TABLE, 'sbp');
+        $sql->join(Shop::addSqlAssociation(self::TABLE, 'sbp'));
 
         return Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql);
     }

--- a/classes/shortcode/BlogPostEntityType.php
+++ b/classes/shortcode/BlogPostEntityType.php
@@ -91,6 +91,7 @@ class BlogPostEntityType extends EntityTypeBase
             ->select('DISTINCT bl.id_bees_blog_post')
             ->from('bees_blog_post_lang', 'bl')
             ->innerJoin('bees_blog_post', 'b', '(b.id_bees_blog_post = bl.id_bees_blog_post)')
+            ->join(Shop::addSqlAssociation('bees_blog_post', 'b'))
             ->innerJoin('lang', 'l', '(l.id_lang = bl.id_lang AND l.active)')
             ->where('b.active')
             ->where('bl.lang_active');
@@ -159,9 +160,10 @@ class BlogPostEntityType extends EntityTypeBase
     {
         $conn = Db::getInstance();
         $blogposts = $conn->getArray((new DbQuery())
-            ->select('DISTINCT bl.id_bees_blog_post, bl.id_lang, bl.link_rewrite')
+            ->select('DISTINCT bl.id_bees_blog_post, bl.id_lang, bl.link_rewrite, b_shop.id_shop')
             ->from('bees_blog_post_lang', 'bl')
             ->innerJoin('bees_blog_post', 'b', '(b.id_bees_blog_post = bl.id_bees_blog_post)')
+            ->join(Shop::addSqlAssociation('bees_blog_post', 'b'))
             ->innerJoin('lang', 'l', '(l.id_lang = bl.id_lang AND l.active)')
             ->where('b.active')
             ->where('bl.lang_active')
@@ -169,16 +171,14 @@ class BlogPostEntityType extends EntityTypeBase
         );
 
         $mapping = [];
-        $shops = Shop::getShops(true, null, true);
 
         foreach ($blogposts as $row) {
-            foreach ($shops as $shopId) {
-                $langId = (int)$row['id_lang'];
-                $blogPostId = (int)$row['id_bees_blog_post'];
-                $linkRewrite = (string)$row['link_rewrite'];
-                $url = BeesBlog::getBeesBlogLink('beesblog_post', ['blog_rewrite' => $linkRewrite], (int)$shopId, $langId);
-                $mapping[$url] = $blogPostId;
-            }
+            $langId = (int)$row['id_lang'];
+            $shopId = (int)$row['id_shop'];
+            $blogPostId = (int)$row['id_bees_blog_post'];
+            $linkRewrite = (string)$row['link_rewrite'];
+            $url = BeesBlog::getBeesBlogLink('beesblog_post', ['blog_rewrite' => $linkRewrite], $shopId, $langId);
+            $mapping[$url] = $blogPostId;
         }
 
         return $mapping;

--- a/controllers/admin/AdminBeesBlogCategoryController.php
+++ b/controllers/admin/AdminBeesBlogCategoryController.php
@@ -53,8 +53,8 @@ class AdminBeesBlogCategoryController extends ModuleAdminController
         // Retrieve the context from a static context, just because
         $this->context = Context::getContext();
 
-        // Only display this page in single store context
-        $this->multishop_context = Shop::CONTEXT_SHOP;
+        // Support multistore context
+        $this->multishop_context = Shop::CONTEXT_ALL;
 
         // Make sure that when we save the `BeesBlogCategory` ObjectModel, the `_shop` table is set, too (primary => id_shop relation)
         Shop::addTableAssociation(BeesBlogCategory::TABLE, ['type' => 'shop']);
@@ -99,6 +99,11 @@ class AdminBeesBlogCategoryController extends ModuleAdminController
                 'orderby' => false,
             ],
         ];
+
+        $this->_join = Shop::addSqlAssociation(BeesBlogCategory::TABLE, 'a');
+        if (Shop::isFeatureActive() && Shop::getContext() != Shop::CONTEXT_SHOP) {
+            $this->_group = 'GROUP BY a.id_bees_blog_category';
+        }
 
         // With all this info set, it's about time to call the parent constructor
         parent::__construct();
@@ -236,6 +241,15 @@ class AdminBeesBlogCategoryController extends ModuleAdminController
         $this->fields_value = [
             'category_image' => $imageUrl
         ];
+
+        if (Shop::isFeatureActive() && Shop::getContext() != Shop::CONTEXT_SHOP) {
+            $this->fields_form['input'][] = [
+                'type'  => 'shop',
+                'label' => $this->l('Shop association'),
+                'name'  => 'checkBoxShopAsso',
+            ];
+            $this->fields_value['checkBoxShopAsso'] = $this->getAssociatedShopIds($id, BeesBlogCategory::SHOP_TABLE, BeesBlogCategory::PRIMARY);
+        }
 
         Media::addJsDef(['PS_ALLOW_ACCENTED_CHARS_URL' => (int) Configuration::get('PS_ALLOW_ACCENTED_CHARS_URL')]);
 
@@ -458,7 +472,7 @@ class AdminBeesBlogCategoryController extends ModuleAdminController
         if (!$blogCategory->position) {
             $blogCategory->position = 0;
         }
-        $blogCategory->id_shop = (int) Context::getContext()->shop->id;
+        $this->setShopAssociation($blogCategory);
         foreach (Language::getLanguages(false, false, true) as $idLang) {
             if (!$blogCategory->link_rewrite[$idLang]) {
                 $blogCategory->link_rewrite[$idLang] = Tools::link_rewrite($blogCategory->title[$idLang]);
@@ -545,7 +559,7 @@ class AdminBeesBlogCategoryController extends ModuleAdminController
         if (!$blogCategory->position) {
             $blogCategory->position = 0;
         }
-        $blogCategory->id_shop = (int) Context::getContext()->shop->id;
+        $this->setShopAssociation($blogCategory);
 
         $this->processImage($_FILES, $blogCategory->id);
 
@@ -652,5 +666,63 @@ class AdminBeesBlogCategoryController extends ModuleAdminController
             }
         }
         return null;
+    }
+
+    /**
+     * @param ObjectModel $object
+     */
+    protected function setShopAssociation(ObjectModel $object)
+    {
+        $shopIds = $this->getSelectedShopIds();
+        $object->id_shop_list = $shopIds;
+        if (Shop::getContext() === Shop::CONTEXT_SHOP) {
+            $object->id_shop = (int) $this->context->shop->id;
+        }
+    }
+
+    /**
+     * @return int[]
+     */
+    protected function getSelectedShopIds()
+    {
+        if (!Shop::isFeatureActive() || Shop::getContext() === Shop::CONTEXT_SHOP) {
+            return [(int) $this->context->shop->id];
+        }
+
+        $selected = Tools::getValue('checkBoxShopAsso');
+        if (is_array($selected)) {
+            $shopIds = array_map('intval', array_keys($selected));
+            if (!$shopIds) {
+                $shopIds = array_map('intval', array_values($selected));
+            }
+            if ($shopIds) {
+                return $shopIds;
+            }
+        }
+
+        return Shop::getContextListShopID();
+    }
+
+    /**
+     * @param int $id
+     * @param string $shopTable
+     * @param string $primary
+     *
+     * @return int[]
+     */
+    protected function getAssociatedShopIds($id, $shopTable, $primary)
+    {
+        if (!$id) {
+            return Shop::getContextListShopID();
+        }
+
+        $rows = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS(
+            'SELECT `id_shop` FROM `'._DB_PREFIX_.bqSQL($shopTable).'`
+             WHERE `'.bqSQL($primary).'` = '.(int) $id
+        );
+        if (!$rows) {
+            return Shop::getContextListShopID();
+        }
+        return array_map('intval', array_column($rows, 'id_shop'));
     }
 }

--- a/controllers/admin/AdminBeesBlogPostController.php
+++ b/controllers/admin/AdminBeesBlogPostController.php
@@ -57,8 +57,8 @@ class AdminBeesBlogPostController extends ModuleAdminController
         // Retrieve the context from a static context, just because
         $this->context = Context::getContext();
 
-        // Only display this page in single store context
-        $this->multishop_context = Shop::CONTEXT_SHOP;
+        // Support multistore context
+        $this->multishop_context = Shop::CONTEXT_ALL;
 
         // Make sure that when we save the `BeesBlogCategory` ObjectModel, the `_shop` table is set, too (primary => id_shop relation)
         Shop::addTableAssociation(BeesBlogPost::TABLE, ['type' => 'shop']);
@@ -126,12 +126,12 @@ class AdminBeesBlogPostController extends ModuleAdminController
         ];
 
         // Set some default HelperList sortings
-        $this->_join = 'LEFT JOIN '._DB_PREFIX_.'bees_blog_post_shop sbs ON a.id_bees_blog_post = sbs.id_bees_blog_post AND sbs.id_shop IN('.implode(',', Shop::getContextListShopID()).')';
+        $this->_join = Shop::addSqlAssociation(BeesBlogPost::TABLE, 'a');
         $this->_defaultOrderBy = 'a.id_bees_blog_post';
         $this->_defaultOrderWay = 'DESC';
 
         if (Shop::isFeatureActive() && Shop::getContext() != Shop::CONTEXT_SHOP) {
-            $this->_group = 'GROUP BY a.bees_blog_post';
+            $this->_group = 'GROUP BY a.id_bees_blog_post';
         }
 
         // Check if there are any categories available
@@ -475,6 +475,15 @@ class AdminBeesBlogPostController extends ModuleAdminController
             'products' => $products,
         ];
 
+        if (Shop::isFeatureActive() && Shop::getContext() != Shop::CONTEXT_SHOP) {
+            $this->fields_form['input'][] = [
+                'type'  => 'shop',
+                'label' => $this->l('Shop association'),
+                'name'  => 'checkBoxShopAsso',
+            ];
+            $this->fields_value['checkBoxShopAsso'] = $this->getAssociatedShopIds($id, BeesBlogPost::SHOP_TABLE, BeesBlogPost::PRIMARY);
+        }
+
         foreach (Language::getLanguages(true) as $language) {
             $this->fields_value['lang_active_'.(int) $language['id_lang']] = (bool) BeesBlogPost::getLangActive(Tools::getValue(BeesBlogPost::PRIMARY), $language['id_lang']);
         }
@@ -655,7 +664,7 @@ class AdminBeesBlogPostController extends ModuleAdminController
 
         $blogPost->id_employee = $this->context->employee->id;
         $blogPost->viewed = 0;
-        $blogPost->id_shop = (int) Context::getContext()->shop->id;
+        $this->setShopAssociation($blogPost);
 
         if ($blogPost->add()) {
             $this->processImage($_FILES, $blogPost->id);
@@ -710,7 +719,7 @@ class AdminBeesBlogPostController extends ModuleAdminController
         $blogPost->lang_active = [];
         $this->copyFromPost($blogPost, $this->table);
 
-        $blogPost->id_shop = (int) Context::getContext()->shop->id;
+        $this->setShopAssociation($blogPost);
         $this->processImage($_FILES, $blogPost->id);
         $this->processProducts($blogPost->id);
         if ($blogPost->update()) {
@@ -856,5 +865,63 @@ class AdminBeesBlogPostController extends ModuleAdminController
             return $post->link;
         }
         return null;
+    }
+
+    /**
+     * @param ObjectModel $object
+     */
+    protected function setShopAssociation(ObjectModel $object)
+    {
+        $shopIds = $this->getSelectedShopIds();
+        $object->id_shop_list = $shopIds;
+        if (Shop::getContext() === Shop::CONTEXT_SHOP) {
+            $object->id_shop = (int) $this->context->shop->id;
+        }
+    }
+
+    /**
+     * @return int[]
+     */
+    protected function getSelectedShopIds()
+    {
+        if (!Shop::isFeatureActive() || Shop::getContext() === Shop::CONTEXT_SHOP) {
+            return [(int) $this->context->shop->id];
+        }
+
+        $selected = Tools::getValue('checkBoxShopAsso');
+        if (is_array($selected)) {
+            $shopIds = array_map('intval', array_keys($selected));
+            if (!$shopIds) {
+                $shopIds = array_map('intval', array_values($selected));
+            }
+            if ($shopIds) {
+                return $shopIds;
+            }
+        }
+
+        return Shop::getContextListShopID();
+    }
+
+    /**
+     * @param int $id
+     * @param string $shopTable
+     * @param string $primary
+     *
+     * @return int[]
+     */
+    protected function getAssociatedShopIds($id, $shopTable, $primary)
+    {
+        if (!$id) {
+            return Shop::getContextListShopID();
+        }
+
+        $rows = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS(
+            'SELECT `id_shop` FROM `'._DB_PREFIX_.bqSQL($shopTable).'`
+             WHERE `'.bqSQL($primary).'` = '.(int) $id
+        );
+        if (!$rows) {
+            return Shop::getContextListShopID();
+        }
+        return array_map('intval', array_column($rows, 'id_shop'));
     }
 }

--- a/upgrade/upgrade-1.7.1.php
+++ b/upgrade/upgrade-1.7.1.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Copyright (C) 2017-2024 thirty bees
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@thirtybees.com so we can send you a copy immediately.
+ *
+ * @author    thirty bees <modules@thirtybees.com>
+ * @copyright 2017-2024 thirty bees
+ * @license   Academic Free License (AFL 3.0)
+ */
+
+if (!defined('_TB_VERSION_')) {
+    exit;
+}
+
+/**
+ * @return bool
+ * @throws PrestaShopDatabaseException
+ * @throws PrestaShopException
+ */
+function upgrade_module_1_7_1()
+{
+    $db = Db::getInstance();
+    $prefix = _DB_PREFIX_;
+
+    $success = true;
+
+    $success = $success && $db->execute(
+        'CREATE TABLE IF NOT EXISTS `'.$prefix.'bees_blog_post_shop` (
+            `id_bees_blog_post` INT(11) UNSIGNED NOT NULL,
+            `id_shop` INT(11) UNSIGNED NOT NULL,
+            PRIMARY KEY (`id_bees_blog_post`, `id_shop`)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci'
+    );
+
+    $success = $success && $db->execute(
+        'CREATE TABLE IF NOT EXISTS `'.$prefix.'bees_blog_category_shop` (
+            `id_bees_blog_category` INT(11) UNSIGNED NOT NULL,
+            `id_shop` INT(11) UNSIGNED NOT NULL,
+            PRIMARY KEY (`id_bees_blog_category`, `id_shop`)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci'
+    );
+
+    $success = $success && $db->execute(
+        'INSERT IGNORE INTO `'.$prefix.'bees_blog_post_shop` (`id_bees_blog_post`, `id_shop`)
+         SELECT p.`id_bees_blog_post`, s.`id_shop`
+         FROM `'.$prefix.'bees_blog_post` p
+         CROSS JOIN `'.$prefix.'shop` s'
+    );
+
+    $success = $success && $db->execute(
+        'INSERT IGNORE INTO `'.$prefix.'bees_blog_category_shop` (`id_bees_blog_category`, `id_shop`)
+         SELECT c.`id_bees_blog_category`, s.`id_shop`
+         FROM `'.$prefix.'bees_blog_category` c
+         CROSS JOIN `'.$prefix.'shop` s'
+    );
+
+    $configKeys = [
+        BeesBlog::POSTS_PER_PAGE,
+        BeesBlog::AUTHOR_STYLE,
+        BeesBlog::MAIN_URL_KEY,
+        BeesBlog::USE_HTML,
+        BeesBlog::ENABLE_COMMENT,
+        BeesBlog::SHOW_AUTHOR,
+        BeesBlog::SHOW_DATE,
+        BeesBlog::SOCIAL_SHARING,
+        BeesBlog::SHOW_POST_COUNT,
+        BeesBlog::SHOW_NO_IMAGE,
+        BeesBlog::CUSTOM_CSS,
+        BeesBlog::SHOW_CATEGORY_IMAGE,
+        BeesBlog::HOME_TITLE,
+        BeesBlog::HOME_KEYWORDS,
+        BeesBlog::HOME_DESCRIPTION,
+        BeesBlog::DISQUS_USERNAME,
+    ];
+
+    $shops = Shop::getShops(false, null, true);
+    foreach ($configKeys as $key) {
+        $globalValue = Configuration::getGlobalValue($key);
+        if ($globalValue === false) {
+            continue;
+        }
+        foreach ($shops as $shopId) {
+            $exists = $db->getValue(
+                'SELECT 1 FROM `'.$prefix.'configuration`
+                 WHERE `name` = \''.pSQL($key).'\' AND `id_shop` = '.(int) $shopId
+            );
+            if (!$exists) {
+                Configuration::updateValue($key, $globalValue, false, null, (int) $shopId);
+            }
+        }
+    }
+
+    return (bool) $success;
+}


### PR DESCRIPTION
### Motivation
- Make the Bees Blog module fully multistore-aware so posts, categories and module configuration can be scoped per shop.  
- Ensure front-end queries, sitemap/shortcode URL generation and back-office workflows respect shop associations.  

### Description
- Add an upgrade script `upgrade/upgrade-1.7.1.php` that creates `bees_blog_post_shop` and `bees_blog_category_shop`, backfills existing posts/categories across all shops, and migrates global `Configuration` keys into per-shop entries when missing.  
- Restrict collections/queries to the current shop by adding `Shop::addSqlAssociation` / `sqlJoin` usage in `classes/BeesBlogPost.php`, `classes/BeesBlogCategory.php`, `beesblog.php` (sitemap), and `classes/shortcode/BlogPostEntityType.php`.  
- Update admin controllers `controllers/admin/AdminBeesBlogPostController.php` and `controllers/admin/AdminBeesBlogCategoryController.php` to support multistore: set `multishop_context` to `Shop::CONTEXT_ALL`, use `Shop::addSqlAssociation` joins, add shop-association checkbox to forms in multi-shop context, and add helper methods to set/read shop associations on save/render.  
- Bump module version to `1.7.1` in `beesblog.php`.  

### Testing
- No automated tests were executed for this change (no test run requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a9cc490bc832d8efc450748bf6424)