### PR TITLE
Make beesblog multistore-aware (shop associations, upgrade & BO changes)

### DIFF
--- a/beesblog.php
+++ b/beesblog.php
@@ -87,7 +87,7 @@ class BeesBlog extends Module
     {
         $this->name = 'beesblog';
         $this->tab = 'front_office_features';
-        $this->version = '1.7.0';
+        $this->version = '1.7.1';
         $this->author = 'thirty bees';
         $this->tb_min_version = '1.0.0';
         $this->tb_versions_compliancy = '> 1.0.0';
@@ -485,36 +485,43 @@ class BeesBlog extends Module
         $langId = (int)Context::getContext()->language->id;
 
         // Blog posts
-        $results = (new PrestaShopCollection('BeesBlogModule\\BeesBlogPost', $langId))
-            ->where('active', '=', 1)
-            ->getResults();
-        if ($results) {
-            /** @var BeesBlogPost $result */
-            foreach ($results as $result) {
-                if ($result->lang_active) {
-                    $link = [];
-                    $link['link'] = $result->link;
-                    $link['lastmod'] = $result->date_upd;
-                    $link['type'] = 'module';
-                    $this->addImageLink($link, BeesBlogPost::getImagePath($result->id, 'post_list_item'));
-                    $links[] = $link;
-                }
+        $postRows = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS(
+            (new DbQuery())
+                ->select('sbp.`id_bees_blog_post`, sbp.`date_upd`, sbpl.`link_rewrite`, sbp_shop.`id_shop`')
+                ->from('bees_blog_post', 'sbp')
+                ->innerJoin('bees_blog_post_lang', 'sbpl', 'sbp.`id_bees_blog_post` = sbpl.`id_bees_blog_post` AND sbpl.`id_lang` = '.(int)$langId)
+                ->join(Shop::addSqlAssociation('bees_blog_post', 'sbp'))
+                ->where('sbp.`active` = 1')
+                ->where('sbpl.`lang_active` = 1')
+        );
+        if ($postRows) {
+            foreach ($postRows as $row) {
+                $link = [];
+                $link['link'] = BeesBlog::getBeesBlogLink('beesblog_post', ['blog_rewrite' => $row['link_rewrite']], (int)$row['id_shop'], $langId);
+                $link['lastmod'] = $row['date_upd'];
+                $link['type'] = 'module';
+                $this->addImageLink($link, BeesBlogPost::getImagePath((int)$row['id_bees_blog_post'], 'post_list_item'));
+                $links[] = $link;
             }
         }
 
         // Categories
-        $results = (new PrestaShopCollection('BeesBlogModule\\BeesBlogCategory', $langId))
-            ->where('active', '=', 1)
-            ->getResults();
+        $categoryRows = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS(
+            (new DbQuery())
+                ->select('sbc.`id_bees_blog_category`, sbc.`date_upd`, sbcl.`link_rewrite`, sbc_shop.`id_shop`')
+                ->from('bees_blog_category', 'sbc')
+                ->innerJoin('bees_blog_category_lang', 'sbcl', 'sbc.`id_bees_blog_category` = sbcl.`id_bees_blog_category` AND sbcl.`id_lang` = '.(int)$langId)
+                ->join(Shop::addSqlAssociation('bees_blog_category', 'sbc'))
+                ->where('sbc.`active` = 1')
+        );
 
-        if ($results) {
-            /** @var BeesBlogCategory $result */
-            foreach ($results as $result) {
+        if ($categoryRows) {
+            foreach ($categoryRows as $row) {
                 $link = [];
-                $link['link'] = $result->link;
-                $link['lastmod'] = $result->date_upd;
+                $link['link'] = BeesBlog::getBeesBlogLink('beesblog_category', ['cat_rewrite' => $row['link_rewrite']], (int)$row['id_shop'], $langId);
+                $link['lastmod'] = $row['date_upd'];
                 $link['type'] = 'module';
-                $this->addImageLink($link, BeesBlogCategory::getImagePath($result->id));
+                $this->addImageLink($link, BeesBlogCategory::getImagePath((int)$row['id_bees_blog_category']));
                 $links[] = $link;
             }
         }

--- a/classes/BeesBlogCategory.php
+++ b/classes/BeesBlogCategory.php
@@ -27,6 +27,7 @@ use DbQuery;
 use ObjectModel;
 use PrestaShopDatabaseException;
 use PrestaShopException;
+use Shop;
 
 if (!defined('_TB_VERSION_')) {
     exit;
@@ -272,6 +273,36 @@ class BeesBlogCategory extends ObjectModel
     }
 
     /**
+     * Create the database tables for BeesBlogCategory model
+     *
+     * @param string|null $className Class name
+     * @return bool Indicates whether the database was successfully added
+     * @throws PrestaShopException
+     */
+    public static function createDatabase($className = null)
+    {
+        return (
+            parent::createDatabase($className) &&
+            static::createShopTable()
+        );
+    }
+
+    /**
+     * Drop the database for BeesBlogCategory model
+     *
+     * @param string|null $className Class name
+     * @return bool Indicates whether the database was successfully dropped
+     * @throws PrestaShopException
+     */
+    public static function dropDatabase($className = null)
+    {
+        return (
+            parent::dropDatabase($className) &&
+            static::dropShopTable()
+        );
+    }
+
+    /**
      * @param string $rewrite Rewrite
      * @param bool $active Active
      * @param int|null $idLang Language ID
@@ -297,9 +328,9 @@ class BeesBlogCategory extends ObjectModel
         $sql->select('sbc.`'.static::PRIMARY.'`');
         $sql->from(static::TABLE, 'sbc');
         $sql->innerJoin(static::LANG_TABLE, 'sbcl', 'sbc.`'.static::PRIMARY.'` = sbcl.`'.static::PRIMARY.'`');
-        $sql->innerJoin(static::SHOP_TABLE, 'sbcs', 'sbc.`'.static::PRIMARY.'` = sbcs.`'.static::PRIMARY.'`');
+        $sql->join(Shop::addSqlAssociation(static::TABLE, 'sbc'));
         $sql->where('sbcl.`id_lang` = '.(int) $idLang);
-        $sql->where('sbcs.`id_shop` = '.(int) $idShop);
+        $sql->where('sbc_shop.`id_shop` = '.(int) $idShop);
         $sql->where('sbc.`active` = '.(int) $active);
         $sql->where('sbcl.`link_rewrite` = \''.pSQL($rewrite).'\'');
 
@@ -334,6 +365,35 @@ class BeesBlogCategory extends ObjectModel
         } else {
             return "{$baseLocation}{$id}-{$type}.jpg";
         }
+    }
+
+    /**
+     * Creates database table to store shop associations
+     *
+     * @return boolean
+     * @throws PrestaShopException
+     */
+    public static function createShopTable()
+    {
+        return Db::getInstance()->execute(
+            'CREATE TABLE IF NOT EXISTS `'._DB_PREFIX_.'bees_blog_category_shop` (
+                `id_bees_blog_category` INT(11) UNSIGNED NOT NULL,
+                `id_shop` INT(11) UNSIGNED NOT NULL,
+                PRIMARY KEY (`id_bees_blog_category`, `id_shop`),
+                KEY `id_shop` (`id_shop`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci'
+        );
+    }
+
+    /**
+     * Drop shop association table
+     *
+     * @return boolean
+     * @throws PrestaShopException
+     */
+    public static function dropShopTable()
+    {
+        return Db::getInstance()->execute('DROP TABLE IF EXISTS `'._DB_PREFIX_.'bees_blog_category_shop`');
     }
 
     /**
@@ -373,16 +433,16 @@ class BeesBlogCategory extends ObjectModel
      */
     public static function getNameById($id, $id_lang = null)
     {
-        if (empty($idLang)) {
-            $idLang = (int) Context::getContext()->language->id;
+        if (empty($id_lang)) {
+            $id_lang = (int) Context::getContext()->language->id;
         }
 
         $sql = new DbQuery();
         $sql->select('sbcl.`title`');
         $sql->from(static::TABLE, 'sbc');
         $sql->innerJoin(static::LANG_TABLE, 'sbcl', 'sbc.`'.static::PRIMARY.'` = sbcl.`'.static::PRIMARY.'`');
-        $sql->innerJoin(static::SHOP_TABLE, 'sbcs', 'sbc.`'.static::PRIMARY.'` = sbcs.`'.static::PRIMARY.'`');
-        $sql->where('sbcl.`id_lang` = '.(int) $idLang);
+        $sql->join(Shop::addSqlAssociation(static::TABLE, 'sbc'));
+        $sql->where('sbcl.`id_lang` = '.(int) $id_lang);
         $sql->where('sbcl.`'.static::PRIMARY.'` = \''.pSQL($id).'\'');
 
         return Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql);

--- a/classes/BeesBlogPost.php
+++ b/classes/BeesBlogPost.php
@@ -28,6 +28,7 @@ use DbQuery;
 use ObjectModel;
 use PrestaShopDatabaseException;
 use PrestaShopException;
+use Shop;
 
 if (!defined('_TB_VERSION_')) {
     exit;
@@ -368,7 +369,8 @@ class BeesBlogPost extends ObjectModel
     {
         $sql = new DbQuery();
         $sql->select('`'.self::PRIMARY.'`');
-        $sql->from(self::TABLE);
+        $sql->from(self::TABLE, 'sbp');
+        $sql->join(Shop::addSqlAssociation(self::TABLE, 'sbp'));
 
         return Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql);
     }
@@ -394,10 +396,10 @@ class BeesBlogPost extends ObjectModel
         $sql->select('sbp.`link_rewrite`');
         $sql->from(self::TABLE, 'sbp');
         $sql->innerJoin(self::LANG_TABLE, 'sbpl', 'sbp.`'.self::PRIMARY.'` = sbpl.`'.self::PRIMARY.'`');
-        $sql->innerJoin(self::SHOP_TABLE, 'sbps', 'sbp.`'.self::PRIMARY.'` = sbps.`'.self::PRIMARY.'`');
+        $sql->join(Shop::addSqlAssociation(self::TABLE, 'sbp'));
         $sql->where('sbpl.`id_lang` = '.(int) $idLang);
         $sql->where('sbpl.`lang_active` = 1');
-        $sql->where('sbps.`id_shop` = '.(int) $idShop);
+        $sql->where('sbp_shop.`id_shop` = '.(int) $idShop);
         $sql->where('sbp.`active` = 1');
         $sql->where('sbp.`'.self::PRIMARY.'` = '.(int) $idPost);
 
@@ -431,9 +433,9 @@ class BeesBlogPost extends ObjectModel
         $sql->select('sbp.`'.self::PRIMARY.'`');
         $sql->from(self::TABLE, 'sbp');
         $sql->innerJoin(self::LANG_TABLE, 'sbpl', 'sbp.`'.self::PRIMARY.'` = sbpl.`'.self::PRIMARY.'`');
-        $sql->innerJoin(self::SHOP_TABLE, 'sbps', 'sbp.`'.self::PRIMARY.'` = sbps.`'.self::PRIMARY.'`');
+        $sql->join(Shop::addSqlAssociation(self::TABLE, 'sbp'));
         $sql->where('sbpl.`id_lang` = '.(int) $idLang);
-        $sql->where('sbps.`id_shop` = '.(int) $idShop);
+        $sql->where('sbp_shop.`id_shop` = '.(int) $idShop);
         $sql->where('sbp.`active` = '.(int) $active);
         $sql->where('sbpl.`lang_active`');
         $sql->where('sbpl.`link_rewrite` = \''.pSQL($rewrite).'\'');
@@ -539,6 +541,7 @@ class BeesBlogPost extends ObjectModel
     {
         return (
             parent::createDatabase($className) &&
+            static::createShopTable() &&
             static::createRelatedProductsTable()
         );
     }
@@ -554,6 +557,7 @@ class BeesBlogPost extends ObjectModel
     {
         return (
             parent::dropDatabase($className) &&
+            static::dropShopTable() &&
             static::dropRelatedProductsTable()
         );
     }
@@ -576,6 +580,24 @@ class BeesBlogPost extends ObjectModel
     }
 
     /**
+     * Creates database table to store shop associations
+     *
+     * @return boolean
+     * @throws PrestaShopException
+     */
+    public static function createShopTable()
+    {
+        return Db::getInstance()->execute(
+            'CREATE TABLE IF NOT EXISTS `'._DB_PREFIX_.'bees_blog_post_shop` (
+                `id_bees_blog_post` INT(11) UNSIGNED NOT NULL,
+                `id_shop` INT(11) UNSIGNED NOT NULL,
+                PRIMARY KEY (`id_bees_blog_post`, `id_shop`),
+                KEY `id_shop` (`id_shop`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci'
+        );
+    }
+
+    /**
      * Drop related products database table
      *
      * @return boolean
@@ -584,5 +606,16 @@ class BeesBlogPost extends ObjectModel
     public static function dropRelatedProductsTable()
     {
         return Db::getInstance()->execute('DROP TABLE IF EXISTS `'._DB_PREFIX_.'bees_blog_post_product`');
+    }
+
+    /**
+     * Drop shop association table
+     *
+     * @return boolean
+     * @throws PrestaShopException
+     */
+    public static function dropShopTable()
+    {
+        return Db::getInstance()->execute('DROP TABLE IF EXISTS `'._DB_PREFIX_.'bees_blog_post_shop`');
     }
 }

--- a/classes/shortcode/BlogPostEntityType.php
+++ b/classes/shortcode/BlogPostEntityType.php
@@ -91,6 +91,7 @@ class BlogPostEntityType extends EntityTypeBase
             ->select('DISTINCT bl.id_bees_blog_post')
             ->from('bees_blog_post_lang', 'bl')
             ->innerJoin('bees_blog_post', 'b', '(b.id_bees_blog_post = bl.id_bees_blog_post)')
+            ->join(Shop::addSqlAssociation('bees_blog_post', 'b'))
             ->innerJoin('lang', 'l', '(l.id_lang = bl.id_lang AND l.active)')
             ->where('b.active')
             ->where('bl.lang_active');
@@ -159,9 +160,10 @@ class BlogPostEntityType extends EntityTypeBase
     {
         $conn = Db::getInstance();
         $blogposts = $conn->getArray((new DbQuery())
-            ->select('DISTINCT bl.id_bees_blog_post, bl.id_lang, bl.link_rewrite')
+            ->select('DISTINCT bl.id_bees_blog_post, bl.id_lang, bl.link_rewrite, b_shop.id_shop')
             ->from('bees_blog_post_lang', 'bl')
             ->innerJoin('bees_blog_post', 'b', '(b.id_bees_blog_post = bl.id_bees_blog_post)')
+            ->join(Shop::addSqlAssociation('bees_blog_post', 'b'))
             ->innerJoin('lang', 'l', '(l.id_lang = bl.id_lang AND l.active)')
             ->where('b.active')
             ->where('bl.lang_active')
@@ -169,16 +171,14 @@ class BlogPostEntityType extends EntityTypeBase
         );
 
         $mapping = [];
-        $shops = Shop::getShops(true, null, true);
 
         foreach ($blogposts as $row) {
-            foreach ($shops as $shopId) {
-                $langId = (int)$row['id_lang'];
-                $blogPostId = (int)$row['id_bees_blog_post'];
-                $linkRewrite = (string)$row['link_rewrite'];
-                $url = BeesBlog::getBeesBlogLink('beesblog_post', ['blog_rewrite' => $linkRewrite], (int)$shopId, $langId);
-                $mapping[$url] = $blogPostId;
-            }
+            $shopId = (int)$row['id_shop'];
+            $langId = (int)$row['id_lang'];
+            $blogPostId = (int)$row['id_bees_blog_post'];
+            $linkRewrite = (string)$row['link_rewrite'];
+            $url = BeesBlog::getBeesBlogLink('beesblog_post', ['blog_rewrite' => $linkRewrite], $shopId, $langId);
+            $mapping[$url] = $blogPostId;
         }
 
         return $mapping;

--- a/controllers/admin/AdminBeesBlogCategoryController.php
+++ b/controllers/admin/AdminBeesBlogCategoryController.php
@@ -53,8 +53,8 @@ class AdminBeesBlogCategoryController extends ModuleAdminController
         // Retrieve the context from a static context, just because
         $this->context = Context::getContext();
 
-        // Only display this page in single store context
-        $this->multishop_context = Shop::CONTEXT_SHOP;
+        // Allow all shop contexts
+        $this->multishop_context = Shop::CONTEXT_ALL;
 
         // Make sure that when we save the `BeesBlogCategory` ObjectModel, the `_shop` table is set, too (primary => id_shop relation)
         Shop::addTableAssociation(BeesBlogCategory::TABLE, ['type' => 'shop']);
@@ -99,6 +99,11 @@ class AdminBeesBlogCategoryController extends ModuleAdminController
                 'orderby' => false,
             ],
         ];
+
+        $this->_join = Shop::addSqlAssociation($this->table, 'a');
+        if (Shop::isFeatureActive() && Shop::getContext() != Shop::CONTEXT_SHOP) {
+            $this->_group = 'GROUP BY a.'.BeesBlogCategory::PRIMARY;
+        }
 
         // With all this info set, it's about time to call the parent constructor
         parent::__construct();
@@ -236,6 +241,15 @@ class AdminBeesBlogCategoryController extends ModuleAdminController
         $this->fields_value = [
             'category_image' => $imageUrl
         ];
+
+        if (Shop::isFeatureActive() && Shop::getContext() != Shop::CONTEXT_SHOP) {
+            $this->fields_form['input'][] = [
+                'type'  => 'shop',
+                'label' => $this->l('Shop association'),
+                'name'  => 'checkBoxShopAsso',
+            ];
+            $this->fields_value['checkBoxShopAsso'] = $this->getAssociatedShopIds($id);
+        }
 
         Media::addJsDef(['PS_ALLOW_ACCENTED_CHARS_URL' => (int) Configuration::get('PS_ALLOW_ACCENTED_CHARS_URL')]);
 
@@ -459,6 +473,8 @@ class AdminBeesBlogCategoryController extends ModuleAdminController
             $blogCategory->position = 0;
         }
         $blogCategory->id_shop = (int) Context::getContext()->shop->id;
+        $shopIds = $this->getShopAssociationIds();
+        $blogCategory->id_shop_list = $shopIds;
         foreach (Language::getLanguages(false, false, true) as $idLang) {
             if (!$blogCategory->link_rewrite[$idLang]) {
                 $blogCategory->link_rewrite[$idLang] = Tools::link_rewrite($blogCategory->title[$idLang]);
@@ -467,6 +483,7 @@ class AdminBeesBlogCategoryController extends ModuleAdminController
 
         // TODO: check if link_rewrite is unique
         if ($blogCategory->add()) {
+            $this->updateShopAssociations($blogCategory->id, $shopIds);
             $this->processImage($_FILES, $blogCategory->id);
             $this->confirmations[] = $this->l('Successfully added a new category');
 
@@ -546,12 +563,15 @@ class AdminBeesBlogCategoryController extends ModuleAdminController
             $blogCategory->position = 0;
         }
         $blogCategory->id_shop = (int) Context::getContext()->shop->id;
+        $shopIds = $this->getShopAssociationIds();
+        $blogCategory->id_shop_list = $shopIds;
 
         $this->processImage($_FILES, $blogCategory->id);
 
         // TODO: check if link_rewrite is unique
 
         if ($blogCategory->update()) {
+            $this->updateShopAssociations($blogCategory->id, $shopIds);
             $this->confirmations[] = $this->l('Successfully updated the category');
 
             if (Tools::isSubmit('submitAdd'.$this->table.'AndStay')) {
@@ -564,6 +584,71 @@ class AdminBeesBlogCategoryController extends ModuleAdminController
         $this->errors[] = $this->l('Unable to update category');
 
         return false;
+    }
+
+    /**
+     * @return int[]
+     */
+    protected function getShopAssociationIds()
+    {
+        if (!Shop::isFeatureActive()) {
+            return [(int)$this->context->shop->id];
+        }
+
+        if (Shop::getContext() === Shop::CONTEXT_SHOP) {
+            return [(int)$this->context->shop->id];
+        }
+
+        $shops = Tools::getValue('checkBoxShopAsso');
+        if (is_array($shops) && !empty($shops)) {
+            return array_map('intval', array_keys($shops));
+        }
+
+        return array_map('intval', Shop::getContextListShopID());
+    }
+
+    /**
+     * @param int $id
+     * @return int[]
+     */
+    protected function getAssociatedShopIds($id)
+    {
+        if (!$id) {
+            return $this->getShopAssociationIds();
+        }
+
+        $rows = Db::getInstance()->executeS(
+            'SELECT `id_shop` FROM `'._DB_PREFIX_.BeesBlogCategory::SHOP_TABLE.'` WHERE `'.BeesBlogCategory::PRIMARY.'` = '.(int)$id
+        );
+
+        if (!$rows) {
+            return $this->getShopAssociationIds();
+        }
+
+        return array_map('intval', array_column($rows, 'id_shop'));
+    }
+
+    /**
+     * @param int $id
+     * @param int[] $shopIds
+     *
+     * @return void
+     */
+    protected function updateShopAssociations($id, array $shopIds)
+    {
+        Db::getInstance()->delete(BeesBlogCategory::SHOP_TABLE, BeesBlogCategory::PRIMARY.' = '.(int)$id);
+        if (!$shopIds) {
+            return;
+        }
+
+        $insert = [];
+        foreach ($shopIds as $shopId) {
+            $insert[] = [
+                BeesBlogCategory::PRIMARY => (int)$id,
+                'id_shop' => (int)$shopId,
+            ];
+        }
+        Db::getInstance()->insert(BeesBlogCategory::SHOP_TABLE, $insert);
     }
 
     /**

--- a/controllers/admin/AdminBeesBlogPostController.php
+++ b/controllers/admin/AdminBeesBlogPostController.php
@@ -57,8 +57,8 @@ class AdminBeesBlogPostController extends ModuleAdminController
         // Retrieve the context from a static context, just because
         $this->context = Context::getContext();
 
-        // Only display this page in single store context
-        $this->multishop_context = Shop::CONTEXT_SHOP;
+        // Allow all shop contexts
+        $this->multishop_context = Shop::CONTEXT_ALL;
 
         // Make sure that when we save the `BeesBlogCategory` ObjectModel, the `_shop` table is set, too (primary => id_shop relation)
         Shop::addTableAssociation(BeesBlogPost::TABLE, ['type' => 'shop']);
@@ -126,12 +126,12 @@ class AdminBeesBlogPostController extends ModuleAdminController
         ];
 
         // Set some default HelperList sortings
-        $this->_join = 'LEFT JOIN '._DB_PREFIX_.'bees_blog_post_shop sbs ON a.id_bees_blog_post = sbs.id_bees_blog_post AND sbs.id_shop IN('.implode(',', Shop::getContextListShopID()).')';
+        $this->_join = Shop::addSqlAssociation($this->table, 'a');
         $this->_defaultOrderBy = 'a.id_bees_blog_post';
         $this->_defaultOrderWay = 'DESC';
 
         if (Shop::isFeatureActive() && Shop::getContext() != Shop::CONTEXT_SHOP) {
-            $this->_group = 'GROUP BY a.bees_blog_post';
+            $this->_group = 'GROUP BY a.'.BeesBlogPost::PRIMARY;
         }
 
         // Check if there are any categories available
@@ -475,6 +475,15 @@ class AdminBeesBlogPostController extends ModuleAdminController
             'products' => $products,
         ];
 
+        if (Shop::isFeatureActive() && Shop::getContext() != Shop::CONTEXT_SHOP) {
+            $this->fields_form['input'][] = [
+                'type'  => 'shop',
+                'label' => $this->l('Shop association'),
+                'name'  => 'checkBoxShopAsso',
+            ];
+            $this->fields_value['checkBoxShopAsso'] = $this->getAssociatedShopIds($id);
+        }
+
         foreach (Language::getLanguages(true) as $language) {
             $this->fields_value['lang_active_'.(int) $language['id_lang']] = (bool) BeesBlogPost::getLangActive(Tools::getValue(BeesBlogPost::PRIMARY), $language['id_lang']);
         }
@@ -656,8 +665,11 @@ class AdminBeesBlogPostController extends ModuleAdminController
         $blogPost->id_employee = $this->context->employee->id;
         $blogPost->viewed = 0;
         $blogPost->id_shop = (int) Context::getContext()->shop->id;
+        $shopIds = $this->getShopAssociationIds();
+        $blogPost->id_shop_list = $shopIds;
 
         if ($blogPost->add()) {
+            $this->updateShopAssociations($blogPost->id, $shopIds);
             $this->processImage($_FILES, $blogPost->id);
             $this->processProducts($blogPost->id);
             $this->confirmations[] = $this->l('Successfully added post');
@@ -711,9 +723,12 @@ class AdminBeesBlogPostController extends ModuleAdminController
         $this->copyFromPost($blogPost, $this->table);
 
         $blogPost->id_shop = (int) Context::getContext()->shop->id;
+        $shopIds = $this->getShopAssociationIds();
+        $blogPost->id_shop_list = $shopIds;
         $this->processImage($_FILES, $blogPost->id);
         $this->processProducts($blogPost->id);
         if ($blogPost->update()) {
+            $this->updateShopAssociations($blogPost->id, $shopIds);
             $this->confirmations[] = $this->l('Successfully updated post');
             if (Tools::isSubmit('submitAdd'.$this->table.'AndStay')) {
                 $this->redirect_after = static::$currentIndex.'&'.$this->identifier.'='.$blogPost->id.'&update'.$this->table.'&token='.$this->token;
@@ -726,6 +741,71 @@ class AdminBeesBlogPostController extends ModuleAdminController
         $this->errors[] = $this->l('Unable to update post');
 
         return false;
+    }
+
+    /**
+     * @return int[]
+     */
+    protected function getShopAssociationIds()
+    {
+        if (!Shop::isFeatureActive()) {
+            return [(int)$this->context->shop->id];
+        }
+
+        if (Shop::getContext() === Shop::CONTEXT_SHOP) {
+            return [(int)$this->context->shop->id];
+        }
+
+        $shops = Tools::getValue('checkBoxShopAsso');
+        if (is_array($shops) && !empty($shops)) {
+            return array_map('intval', array_keys($shops));
+        }
+
+        return array_map('intval', Shop::getContextListShopID());
+    }
+
+    /**
+     * @param int $id
+     * @return int[]
+     */
+    protected function getAssociatedShopIds($id)
+    {
+        if (!$id) {
+            return $this->getShopAssociationIds();
+        }
+
+        $rows = Db::getInstance()->executeS(
+            'SELECT `id_shop` FROM `'._DB_PREFIX_.BeesBlogPost::SHOP_TABLE.'` WHERE `'.BeesBlogPost::PRIMARY.'` = '.(int)$id
+        );
+
+        if (!$rows) {
+            return $this->getShopAssociationIds();
+        }
+
+        return array_map('intval', array_column($rows, 'id_shop'));
+    }
+
+    /**
+     * @param int $id
+     * @param int[] $shopIds
+     *
+     * @return void
+     */
+    protected function updateShopAssociations($id, array $shopIds)
+    {
+        Db::getInstance()->delete(BeesBlogPost::SHOP_TABLE, BeesBlogPost::PRIMARY.' = '.(int)$id);
+        if (!$shopIds) {
+            return;
+        }
+
+        $insert = [];
+        foreach ($shopIds as $shopId) {
+            $insert[] = [
+                BeesBlogPost::PRIMARY => (int)$id,
+                'id_shop' => (int)$shopId,
+            ];
+        }
+        Db::getInstance()->insert(BeesBlogPost::SHOP_TABLE, $insert);
     }
 
     /**

--- a/upgrade/upgrade-1.7.1.php
+++ b/upgrade/upgrade-1.7.1.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Copyright (C) 2017-2024 thirty bees
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@thirtybees.com so we can send you a copy immediately.
+ *
+ * @author    thirty bees <modules@thirtybees.com>
+ * @copyright 2017-2024 thirty bees
+ * @license   Academic Free License (AFL 3.0)
+ */
+
+if (!defined('_TB_VERSION_')) {
+    exit;
+}
+
+/**
+ * @return bool
+ * @throws PrestaShopDatabaseException
+ * @throws PrestaShopException
+ */
+function upgrade_module_1_7_1()
+{
+    $db = Db::getInstance();
+
+    $db->execute(
+        'CREATE TABLE IF NOT EXISTS `'._DB_PREFIX_.'bees_blog_post_shop` (
+            `id_bees_blog_post` INT(11) UNSIGNED NOT NULL,
+            `id_shop` INT(11) UNSIGNED NOT NULL,
+            PRIMARY KEY (`id_bees_blog_post`, `id_shop`),
+            KEY `id_shop` (`id_shop`)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci'
+    );
+
+    $db->execute(
+        'CREATE TABLE IF NOT EXISTS `'._DB_PREFIX_.'bees_blog_category_shop` (
+            `id_bees_blog_category` INT(11) UNSIGNED NOT NULL,
+            `id_shop` INT(11) UNSIGNED NOT NULL,
+            PRIMARY KEY (`id_bees_blog_category`, `id_shop`),
+            KEY `id_shop` (`id_shop`)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci'
+    );
+
+    $db->execute(
+        'INSERT IGNORE INTO `'._DB_PREFIX_.'bees_blog_post_shop` (`id_bees_blog_post`, `id_shop`)
+        SELECT p.`id_bees_blog_post`, s.`id_shop`
+        FROM `'._DB_PREFIX_.'bees_blog_post` p
+        CROSS JOIN `'._DB_PREFIX_.'shop` s'
+    );
+
+    $db->execute(
+        'INSERT IGNORE INTO `'._DB_PREFIX_.'bees_blog_category_shop` (`id_bees_blog_category`, `id_shop`)
+        SELECT c.`id_bees_blog_category`, s.`id_shop`
+        FROM `'._DB_PREFIX_.'bees_blog_category` c
+        CROSS JOIN `'._DB_PREFIX_.'shop` s'
+    );
+
+    $configKeys = [
+        BeesBlog::POSTS_PER_PAGE,
+        BeesBlog::AUTHOR_STYLE,
+        BeesBlog::MAIN_URL_KEY,
+        BeesBlog::USE_HTML,
+        BeesBlog::ENABLE_COMMENT,
+        BeesBlog::SHOW_AUTHOR,
+        BeesBlog::SHOW_DATE,
+        BeesBlog::SOCIAL_SHARING,
+        BeesBlog::SHOW_POST_COUNT,
+        BeesBlog::SHOW_NO_IMAGE,
+        BeesBlog::CUSTOM_CSS,
+        BeesBlog::SHOW_CATEGORY_IMAGE,
+        BeesBlog::HOME_TITLE,
+        BeesBlog::HOME_KEYWORDS,
+        BeesBlog::HOME_DESCRIPTION,
+        BeesBlog::DISQUS_USERNAME,
+    ];
+
+    $shops = Shop::getShops(true, null, true);
+    foreach ($configKeys as $configKey) {
+        $globalValue = Configuration::getGlobalValue($configKey);
+        if ($globalValue === false) {
+            continue;
+        }
+        foreach ($shops as $shopId) {
+            $exists = (bool)$db->getValue(
+                'SELECT 1 FROM `'._DB_PREFIX_.'configuration` WHERE `name` = \''.pSQL($configKey).'\' AND `id_shop` = '.(int)$shopId.' AND `id_shop_group` IS NULL'
+            );
+            if (!$exists) {
+                Configuration::updateValue($configKey, $globalValue, false, null, (int)$shopId);
+            }
+        }
+    }
+
+    return true;
+}


### PR DESCRIPTION
### Motivation

- Scope blog posts and categories to individual shops so the module behaves correctly in multistore environments. 
- Ensure existing installations can migrate to multistore by creating association tables and backfilling current data and configuration. 
- Provide shop-aware back office flows so admins can manage per-shop associations from the UI.

### Description

- Added shop association support: created `bees_blog_post_shop` and `bees_blog_category_shop` creation/drop helpers in `classes/BeesBlogPost.php` and `classes/BeesBlogCategory.php` and added an upgrade script `upgrade/upgrade-1.7.1.php` that creates these tables, backfills existing rows via `CROSS JOIN ps_shop`, and migrates global `Configuration` keys into per-shop values when missing. 
- Scoped data queries to the current shop context by using `Shop::addSqlAssociation(...)` / `..._shop` aliases and restricting on `id_shop` in model methods such as `BeesBlogPost::getIdByRewrite`, `getPostRewriteById`, `BeesBlogCategory::getIdByRewrite`, `getNameById`, and sitemap/shortcode URL generation. 
- Made sitemap generation shop-aware in `beesblog.php::hookGSitemapAppendUrls()` and updated `classes/shortcode/BlogPostEntityType.php::getAllUrls()` to produce shop-specific URLs. 
- Updated back office controllers to support multistore: switched to `Shop::CONTEXT_ALL`, used `Shop::addSqlAssociation(...)` for list joins, exposed the native shop association helper on forms when in all-shop context, and added helper methods to read/update `*_shop` associations in `controllers/admin/AdminBeesBlogPostController.php` and `controllers/admin/AdminBeesBlogCategoryController.php`. 
- Bumped module version to `1.7.1`.

### Testing

- No automated tests were executed as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a9cc490bc832d8efc450748bf6424)