### PR TITLE
Make beesblog multistore-aware for posts and categories

### DIFF
--- a/beesblog.php
+++ b/beesblog.php
@@ -87,7 +87,7 @@ class BeesBlog extends Module
     {
         $this->name = 'beesblog';
         $this->tab = 'front_office_features';
-        $this->version = '1.7.0';
+        $this->version = '1.7.1';
         $this->author = 'thirty bees';
         $this->tb_min_version = '1.0.0';
         $this->tb_versions_compliancy = '> 1.0.0';
@@ -483,40 +483,55 @@ class BeesBlog extends Module
     {
         $links = [];
         $langId = (int)Context::getContext()->language->id;
+        $shopId = (int)Context::getContext()->shop->id;
 
         // Blog posts
-        $results = (new PrestaShopCollection('BeesBlogModule\\BeesBlogPost', $langId))
-            ->where('active', '=', 1)
-            ->getResults();
-        if ($results) {
-            /** @var BeesBlogPost $result */
-            foreach ($results as $result) {
-                if ($result->lang_active) {
-                    $link = [];
-                    $link['link'] = $result->link;
-                    $link['lastmod'] = $result->date_upd;
-                    $link['type'] = 'module';
-                    $this->addImageLink($link, BeesBlogPost::getImagePath($result->id, 'post_list_item'));
-                    $links[] = $link;
-                }
+        $postQuery = new DbQuery();
+        $postQuery->select('DISTINCT p.`'.BeesBlogPost::PRIMARY.'`');
+        $postQuery->from(BeesBlogPost::TABLE, 'p');
+        $postQuery->innerJoin(BeesBlogPost::LANG_TABLE, 'pl', 'p.`'.BeesBlogPost::PRIMARY.'` = pl.`'.BeesBlogPost::PRIMARY.'`');
+        $postQuery->join(Shop::addSqlAssociation(BeesBlogPost::TABLE, 'p'));
+        $postQuery->where('pl.`id_lang` = '.$langId);
+        $postQuery->where('pl.`lang_active` = 1');
+        $postQuery->where('p.`active` = 1');
+
+        $postRows = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($postQuery);
+        foreach ($postRows as $row) {
+            $postId = (int) $row[BeesBlogPost::PRIMARY];
+            if (!$postId) {
+                continue;
             }
-        }
-
-        // Categories
-        $results = (new PrestaShopCollection('BeesBlogModule\\BeesBlogCategory', $langId))
-            ->where('active', '=', 1)
-            ->getResults();
-
-        if ($results) {
-            /** @var BeesBlogCategory $result */
-            foreach ($results as $result) {
+            $result = new BeesBlogPost($postId, $langId, $shopId);
+            if ($result->lang_active) {
                 $link = [];
                 $link['link'] = $result->link;
                 $link['lastmod'] = $result->date_upd;
                 $link['type'] = 'module';
-                $this->addImageLink($link, BeesBlogCategory::getImagePath($result->id));
+                $this->addImageLink($link, BeesBlogPost::getImagePath($result->id, 'post_list_item'));
                 $links[] = $link;
             }
+        }
+
+        // Categories
+        $categoryQuery = new DbQuery();
+        $categoryQuery->select('DISTINCT c.`'.BeesBlogCategory::PRIMARY.'`');
+        $categoryQuery->from(BeesBlogCategory::TABLE, 'c');
+        $categoryQuery->join(Shop::addSqlAssociation(BeesBlogCategory::TABLE, 'c'));
+        $categoryQuery->where('c.`active` = 1');
+
+        $categoryRows = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($categoryQuery);
+        foreach ($categoryRows as $row) {
+            $categoryId = (int) $row[BeesBlogCategory::PRIMARY];
+            if (!$categoryId) {
+                continue;
+            }
+            $result = new BeesBlogCategory($categoryId, $langId, $shopId);
+            $link = [];
+            $link['link'] = $result->link;
+            $link['lastmod'] = $result->date_upd;
+            $link['type'] = 'module';
+            $this->addImageLink($link, BeesBlogCategory::getImagePath($result->id));
+            $links[] = $link;
         }
 
         return $links;

--- a/classes/BeesBlogCategory.php
+++ b/classes/BeesBlogCategory.php
@@ -20,13 +20,13 @@
 namespace BeesBlogModule;
 
 use BeesBlog;
-use PrestaShopCollection as Collection;
 use Context;
 use Db;
 use DbQuery;
 use ObjectModel;
 use PrestaShopDatabaseException;
 use PrestaShopException;
+use Shop;
 
 if (!defined('_TB_VERSION_')) {
     exit;
@@ -203,20 +203,51 @@ class BeesBlogCategory extends ObjectModel
      */
     public function getPostsInCategory($idLang = null, $page = 0, $limit = 0, $count = false, $raw = false, $propertyFilter = [])
     {
-        $postCollection = new Collection('BeesBlogModule\\BeesBlogPost', $idLang);
-        $postCollection->setPageSize($limit);
-        $postCollection->setPageNumber($page);
-        $postCollection->orderBy('published', 'desc');
-        $postCollection->where('published', '<=', date('Y-m-d H:i:s'));
-        $postCollection->where('id_category', '=', $this->id);
-        $postCollection->where('active', '=', '1');
-        $postCollection->sqlWhere('lang_active = \'1\'');
+        $idLang = $idLang ?: (int) Context::getContext()->language->id;
+        $query = new DbQuery();
+        $query->select('DISTINCT p.`'.BeesBlogPost::PRIMARY.'`');
+        $query->from(BeesBlogPost::TABLE, 'p');
+        $query->innerJoin(BeesBlogPost::LANG_TABLE, 'pl', 'p.`'.BeesBlogPost::PRIMARY.'` = pl.`'.BeesBlogPost::PRIMARY.'`');
+        $query->join(Shop::addSqlAssociation(BeesBlogPost::TABLE, 'p'));
+        $query->where('pl.`id_lang` = '.(int) $idLang);
+        $query->where('pl.`lang_active` = 1');
+        $query->where('p.`published` <= \''.pSQL(date('Y-m-d H:i:s')).'\'');
+        $query->where('p.`id_category` = '.(int) $this->id);
+        $query->where('p.`active` = 1');
+        $query->groupBy('p.`'.BeesBlogPost::PRIMARY.'`');
+        $query->orderBy('p.`published` DESC');
 
         if ($count) {
-            return $postCollection->count();
+            $countQuery = new DbQuery();
+            $countQuery->select('COUNT(DISTINCT p.`'.BeesBlogPost::PRIMARY.'`)');
+            $countQuery->from(BeesBlogPost::TABLE, 'p');
+            $countQuery->innerJoin(BeesBlogPost::LANG_TABLE, 'pl', 'p.`'.BeesBlogPost::PRIMARY.'` = pl.`'.BeesBlogPost::PRIMARY.'`');
+            $countQuery->join(Shop::addSqlAssociation(BeesBlogPost::TABLE, 'p'));
+            $countQuery->where('pl.`id_lang` = '.(int) $idLang);
+            $countQuery->where('pl.`lang_active` = 1');
+            $countQuery->where('p.`published` <= \''.pSQL(date('Y-m-d H:i:s')).'\'');
+            $countQuery->where('p.`id_category` = '.(int) $this->id);
+            $countQuery->where('p.`active` = 1');
+
+            return (int) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($countQuery);
         }
 
-        $results = $postCollection->getResults();
+        if ($limit > 0) {
+            $page = (int) $page;
+            $offset = max($page - 1, 0) * (int) $limit;
+            $query->limit((int) $limit, $offset);
+        }
+
+        $rows = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($query);
+        $results = [];
+        $idShop = (int) Context::getContext()->shop->id;
+        foreach ($rows as $row) {
+            $id = (int) $row[BeesBlogPost::PRIMARY];
+            if ($id) {
+                $results[] = new BeesBlogPost($id, $idLang, $idShop);
+            }
+        }
+
         static::filterCollectionResults($results, $raw, $propertyFilter);
 
         return $results;
@@ -237,15 +268,37 @@ class BeesBlogCategory extends ObjectModel
      */
     public static function getCategories($idLang = null, $page = 0, $limit = 0, $count = false, $raw = false, $propertyFilter = [])
     {
-        $categoryCollection = new Collection('BeesBlogModule\\BeesBlogCategory', $idLang);
-        $categoryCollection->setPageSize($limit);
-        $categoryCollection->setPageNumber($page);
+        $idLang = $idLang ?: (int) Context::getContext()->language->id;
+        $query = new DbQuery();
+        $query->select('DISTINCT c.`'.self::PRIMARY.'`');
+        $query->from(self::TABLE, 'c');
+        $query->join(Shop::addSqlAssociation(self::TABLE, 'c'));
+        $query->groupBy('c.`'.self::PRIMARY.'`');
 
         if ($count) {
-            return $categoryCollection->count();
+            $countQuery = new DbQuery();
+            $countQuery->select('COUNT(DISTINCT c.`'.self::PRIMARY.'`)');
+            $countQuery->from(self::TABLE, 'c');
+            $countQuery->join(Shop::addSqlAssociation(self::TABLE, 'c'));
+            return (int) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($countQuery);
         }
 
-        $results = $categoryCollection->getResults();
+        if ($limit > 0) {
+            $page = (int) $page;
+            $offset = max($page - 1, 0) * (int) $limit;
+            $query->limit((int) $limit, $offset);
+        }
+
+        $rows = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($query);
+        $results = [];
+        $idShop = (int) Context::getContext()->shop->id;
+        foreach ($rows as $row) {
+            $id = (int) $row[self::PRIMARY];
+            if ($id) {
+                $results[] = new BeesBlogCategory($id, $idLang, $idShop);
+            }
+        }
+
         static::filterCollectionResults($results, $raw, $propertyFilter);
 
         return $results;
@@ -263,12 +316,19 @@ class BeesBlogCategory extends ObjectModel
             $idLang = (int) Context::getContext()->language->id;
         }
 
-        $categoryCollection = new Collection('BeesBlogModule\\BeesBlogCategory', $idLang);
-        $categoryCollection->where('id_parent', '=', 0);
+        $query = new DbQuery();
+        $query->select('c.`'.self::PRIMARY.'`');
+        $query->from(self::TABLE, 'c');
+        $query->join(Shop::addSqlAssociation(self::TABLE, 'c'));
+        $query->where('c.`id_parent` = 0');
+        $query->orderBy('c.`'.self::PRIMARY.'` ASC');
 
-        /** @var BeesBlogCategory|false $ret */
-        $ret = $categoryCollection->getFirst();
-        return $ret;
+        $id = (int) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($query);
+        if ($id) {
+            return new BeesBlogCategory($id, $idLang, (int) Context::getContext()->shop->id);
+        }
+
+        return false;
     }
 
     /**
@@ -297,9 +357,9 @@ class BeesBlogCategory extends ObjectModel
         $sql->select('sbc.`'.static::PRIMARY.'`');
         $sql->from(static::TABLE, 'sbc');
         $sql->innerJoin(static::LANG_TABLE, 'sbcl', 'sbc.`'.static::PRIMARY.'` = sbcl.`'.static::PRIMARY.'`');
-        $sql->innerJoin(static::SHOP_TABLE, 'sbcs', 'sbc.`'.static::PRIMARY.'` = sbcs.`'.static::PRIMARY.'`');
+        $sql->join(Shop::addSqlAssociation(static::TABLE, 'sbc'));
         $sql->where('sbcl.`id_lang` = '.(int) $idLang);
-        $sql->where('sbcs.`id_shop` = '.(int) $idShop);
+        $sql->where('`'.static::TABLE.'_shop`.`id_shop` = '.(int) $idShop);
         $sql->where('sbc.`active` = '.(int) $active);
         $sql->where('sbcl.`link_rewrite` = \''.pSQL($rewrite).'\'');
 
@@ -373,18 +433,73 @@ class BeesBlogCategory extends ObjectModel
      */
     public static function getNameById($id, $id_lang = null)
     {
-        if (empty($idLang)) {
-            $idLang = (int) Context::getContext()->language->id;
+        if (empty($id_lang)) {
+            $id_lang = (int) Context::getContext()->language->id;
         }
 
         $sql = new DbQuery();
         $sql->select('sbcl.`title`');
         $sql->from(static::TABLE, 'sbc');
         $sql->innerJoin(static::LANG_TABLE, 'sbcl', 'sbc.`'.static::PRIMARY.'` = sbcl.`'.static::PRIMARY.'`');
-        $sql->innerJoin(static::SHOP_TABLE, 'sbcs', 'sbc.`'.static::PRIMARY.'` = sbcs.`'.static::PRIMARY.'`');
-        $sql->where('sbcl.`id_lang` = '.(int) $idLang);
+        $sql->join(Shop::addSqlAssociation(static::TABLE, 'sbc'));
+        $sql->where('sbcl.`id_lang` = '.(int) $id_lang);
         $sql->where('sbcl.`'.static::PRIMARY.'` = \''.pSQL($id).'\'');
 
         return Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql);
+    }
+
+    /**
+     * Create the database tables for BeesBlogCategory model
+     *
+     * @param string|null $className Class name
+     * @return bool Indicates whether the database was successfully added
+     * @throws PrestaShopException
+     */
+    public static function createDatabase($className = null)
+    {
+        return (
+            parent::createDatabase($className) &&
+            static::createShopTable()
+        );
+    }
+
+    /**
+     * Drop the database for BeesBlogCategory model
+     *
+     * @param string|null $className Class name
+     * @return bool Indicates whether the database was successfully dropped
+     * @throws PrestaShopException
+     */
+    public static function dropDatabase($className = null)
+    {
+        return (
+            parent::dropDatabase($className) &&
+            static::dropShopTable()
+        );
+    }
+
+    /**
+     * @return bool
+     * @throws PrestaShopException
+     */
+    protected static function createShopTable()
+    {
+        return Db::getInstance()->execute(
+            'CREATE TABLE IF NOT EXISTS `'._DB_PREFIX_.'bees_blog_category_shop` (
+               `id_bees_blog_category` INT(11) UNSIGNED NOT NULL,
+               `id_shop` INT(11) UNSIGNED NOT NULL,
+               PRIMARY KEY (`id_bees_blog_category`, `id_shop`),
+               KEY `id_shop` (`id_shop`)
+             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci'
+        );
+    }
+
+    /**
+     * @return bool
+     * @throws PrestaShopException
+     */
+    protected static function dropShopTable()
+    {
+        return Db::getInstance()->execute('DROP TABLE IF EXISTS `'._DB_PREFIX_.'bees_blog_category_shop`');
     }
 }

--- a/classes/BeesBlogPost.php
+++ b/classes/BeesBlogPost.php
@@ -21,13 +21,13 @@ namespace BeesBlogModule;
 
 use BeesBlog;
 use Employee;
-use PrestaShopCollection as Collection;
 use Context;
 use Db;
 use DbQuery;
 use ObjectModel;
 use PrestaShopDatabaseException;
 use PrestaShopException;
+use Shop;
 
 if (!defined('_TB_VERSION_')) {
     exit;
@@ -261,35 +261,18 @@ class BeesBlogPost extends ObjectModel
      */
     public static function getPosts($idLang = null, $page = 0, $limit = 0, $count = false, $raw = false, $propertyFilter = [])
     {
-        $postCollection = new Collection('BeesBlogModule\\BeesBlogPost', $idLang);
-        $postCollection->setPageSize($limit);
-        $postCollection->setPageNumber($page);
-        $postCollection->orderBy('published', 'desc');
-        $postCollection->where('published', '<=', date('Y-m-d H:i:s'));
-        $postCollection->where('active', '=', '1');
-        $postCollection->sqlWhere('lang_active = \'1\'');
+        $idLang = $idLang ?: (int) Context::getContext()->language->id;
+        $query = static::buildPostsQuery($idLang)
+            ->orderBy('p.`published` DESC');
 
         if ($count) {
-            return $postCollection->count();
+            $countQuery = static::buildPostsQuery($idLang, 'COUNT(DISTINCT p.`'.self::PRIMARY.'`)', false);
+            return (int) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($countQuery);
         }
 
-        $results = $postCollection->getResults();
-
-        if ($raw) {
-            $newResults = [];
-            foreach ($postCollection as $post) {
-                if (!empty($propertyFilter)) {
-                    $newPost = [];
-                    foreach ($propertyFilter as $filter) {
-                        $newPost[$filter] = $post->{$filter};
-                    }
-                    $newResults[] = $newPost;
-                } else {
-                    $newResults[] = (array) $post;
-                }
-            }
-            $results = $newResults;
-        }
+        $rows = static::fetchPagedIds($query, $page, $limit);
+        $results = static::hydratePostsFromRows($rows, $idLang);
+        static::filterCollectionResults($results, $raw, $propertyFilter);
 
         return $results;
     }
@@ -309,34 +292,18 @@ class BeesBlogPost extends ObjectModel
      */
     public static function getPopularPosts($idLang = null, $page = 0, $limit = 0, $count = false, $raw = false, $propertyFilter = [])
     {
-        $postCollection = new Collection('BeesBlogModule\\BeesBlogPost', $idLang);
-        $postCollection->setPageSize($limit);
-        $postCollection->setPageNumber($page);
-        $postCollection->orderBy('viewed', 'desc');
-        $postCollection->where('published', '<=', date('Y-m-d H:i:s'));
-        $postCollection->sqlWhere('lang_active = \'1\'');
+        $idLang = $idLang ?: (int) Context::getContext()->language->id;
+        $query = static::buildPostsQuery($idLang)
+            ->orderBy('p.`viewed` DESC');
 
         if ($count) {
-            return $postCollection->count();
+            $countQuery = static::buildPostsQuery($idLang, 'COUNT(DISTINCT p.`'.self::PRIMARY.'`)', false);
+            return (int) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($countQuery);
         }
 
-        $results = $postCollection->getResults();
-
-        if ($raw) {
-            $newResults = [];
-            foreach ($postCollection as $post) {
-                if (!empty($propertyFilter)) {
-                    $newPost = [];
-                    foreach ($propertyFilter as $filter) {
-                        $newPost[$filter] = $post->{$filter};
-                    }
-                    $newResults[] = $newPost;
-                } else {
-                    $newResults[] = (array) $post;
-                }
-            }
-            $results = $newResults;
-        }
+        $rows = static::fetchPagedIds($query, $page, $limit);
+        $results = static::hydratePostsFromRows($rows, $idLang);
+        static::filterCollectionResults($results, $raw, $propertyFilter);
 
         return $results;
     }
@@ -366,9 +333,10 @@ class BeesBlogPost extends ObjectModel
      */
     public static function getBlogImage()
     {
-        $sql = new DbQuery();
-        $sql->select('`'.self::PRIMARY.'`');
-        $sql->from(self::TABLE);
+        $sql = (new DbQuery())
+            ->select('p.`'.self::PRIMARY.'`')
+            ->from(self::TABLE, 'p')
+            ->join(Shop::addSqlAssociation(self::TABLE, 'p'));
 
         return Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql);
     }
@@ -394,10 +362,10 @@ class BeesBlogPost extends ObjectModel
         $sql->select('sbp.`link_rewrite`');
         $sql->from(self::TABLE, 'sbp');
         $sql->innerJoin(self::LANG_TABLE, 'sbpl', 'sbp.`'.self::PRIMARY.'` = sbpl.`'.self::PRIMARY.'`');
-        $sql->innerJoin(self::SHOP_TABLE, 'sbps', 'sbp.`'.self::PRIMARY.'` = sbps.`'.self::PRIMARY.'`');
+        $sql->join(Shop::addSqlAssociation(self::TABLE, 'sbp'));
         $sql->where('sbpl.`id_lang` = '.(int) $idLang);
         $sql->where('sbpl.`lang_active` = 1');
-        $sql->where('sbps.`id_shop` = '.(int) $idShop);
+        $sql->where('`'.self::TABLE.'_shop`.`id_shop` = '.(int) $idShop);
         $sql->where('sbp.`active` = 1');
         $sql->where('sbp.`'.self::PRIMARY.'` = '.(int) $idPost);
 
@@ -431,9 +399,9 @@ class BeesBlogPost extends ObjectModel
         $sql->select('sbp.`'.self::PRIMARY.'`');
         $sql->from(self::TABLE, 'sbp');
         $sql->innerJoin(self::LANG_TABLE, 'sbpl', 'sbp.`'.self::PRIMARY.'` = sbpl.`'.self::PRIMARY.'`');
-        $sql->innerJoin(self::SHOP_TABLE, 'sbps', 'sbp.`'.self::PRIMARY.'` = sbps.`'.self::PRIMARY.'`');
+        $sql->join(Shop::addSqlAssociation(self::TABLE, 'sbp'));
         $sql->where('sbpl.`id_lang` = '.(int) $idLang);
-        $sql->where('sbps.`id_shop` = '.(int) $idShop);
+        $sql->where('`'.self::TABLE.'_shop`.`id_shop` = '.(int) $idShop);
         $sql->where('sbp.`active` = '.(int) $active);
         $sql->where('sbpl.`lang_active`');
         $sql->where('sbpl.`link_rewrite` = \''.pSQL($rewrite).'\'');
@@ -539,6 +507,7 @@ class BeesBlogPost extends ObjectModel
     {
         return (
             parent::createDatabase($className) &&
+            static::createShopTable() &&
             static::createRelatedProductsTable()
         );
     }
@@ -554,6 +523,7 @@ class BeesBlogPost extends ObjectModel
     {
         return (
             parent::dropDatabase($className) &&
+            static::dropShopTable() &&
             static::dropRelatedProductsTable()
         );
     }
@@ -584,5 +554,122 @@ class BeesBlogPost extends ObjectModel
     public static function dropRelatedProductsTable()
     {
         return Db::getInstance()->execute('DROP TABLE IF EXISTS `'._DB_PREFIX_.'bees_blog_post_product`');
+    }
+
+    /**
+     * @return bool
+     * @throws PrestaShopException
+     */
+    protected static function createShopTable()
+    {
+        return Db::getInstance()->execute(
+            'CREATE TABLE IF NOT EXISTS `'._DB_PREFIX_.'bees_blog_post_shop` (
+               `id_bees_blog_post` INT(11) UNSIGNED NOT NULL,
+               `id_shop` INT(11) UNSIGNED NOT NULL,
+               PRIMARY KEY (`id_bees_blog_post`, `id_shop`),
+               KEY `id_shop` (`id_shop`)
+             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci'
+        );
+    }
+
+    /**
+     * @return bool
+     * @throws PrestaShopException
+     */
+    protected static function dropShopTable()
+    {
+        return Db::getInstance()->execute('DROP TABLE IF EXISTS `'._DB_PREFIX_.'bees_blog_post_shop`');
+    }
+
+    /**
+     * @param DbQuery $query
+     * @param int $page
+     * @param int $limit
+     *
+     * @return array
+     */
+    protected static function fetchPagedIds(DbQuery $query, $page, $limit)
+    {
+        if ($limit > 0) {
+            $page = (int) $page;
+            $offset = max($page - 1, 0) * (int) $limit;
+            $query->limit((int) $limit, $offset);
+        }
+
+        return Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($query);
+    }
+
+    /**
+     * @param int $idLang
+     * @param string|null $select
+     * @param bool $groupBy
+     *
+     * @return DbQuery
+     */
+    protected static function buildPostsQuery($idLang, $select = null, $groupBy = true)
+    {
+        $query = new DbQuery();
+        if ($select) {
+            $query->select($select);
+        } else {
+            $query->select('DISTINCT p.`'.self::PRIMARY.'`');
+        }
+        $query->from(self::TABLE, 'p');
+        $query->innerJoin(self::LANG_TABLE, 'pl', 'p.`'.self::PRIMARY.'` = pl.`'.self::PRIMARY.'`');
+        $query->join(Shop::addSqlAssociation(self::TABLE, 'p'));
+        $query->where('pl.`id_lang` = '.(int) $idLang);
+        $query->where('pl.`lang_active` = 1');
+        $query->where('p.`published` <= \''.pSQL(date('Y-m-d H:i:s')).'\'');
+        $query->where('p.`active` = 1');
+        if ($groupBy) {
+            $query->groupBy('p.`'.self::PRIMARY.'`');
+        }
+
+        return $query;
+    }
+
+    /**
+     * @param array $rows
+     * @param int $idLang
+     *
+     * @return BeesBlogPost[]
+     * @throws PrestaShopException
+     */
+    protected static function hydratePostsFromRows(array $rows, $idLang)
+    {
+        $results = [];
+        $idShop = (int) Context::getContext()->shop->id;
+        foreach ($rows as $row) {
+            $id = (int) $row[self::PRIMARY];
+            if ($id) {
+                $results[] = new BeesBlogPost($id, $idLang, $idShop);
+            }
+        }
+
+        return $results;
+    }
+
+    /**
+     * @param array $results
+     * @param bool $raw
+     * @param array $propertyFilter
+     */
+    protected static function filterCollectionResults(&$results, $raw, $propertyFilter)
+    {
+        if ($raw) {
+            $newResults = [];
+            foreach ($results as $result) {
+                if (!empty($propertyFilter)) {
+                    $newPost = [];
+                    foreach ($propertyFilter as $filter) {
+                        $newPost[$filter] = $result->{$filter};
+                    }
+                    $newResults[] = $newPost;
+                } else {
+                    $newResults[] = (array) $result;
+                }
+            }
+            $results = $newResults;
+        }
     }
 }

--- a/classes/shortcode/BlogPostEntityType.php
+++ b/classes/shortcode/BlogPostEntityType.php
@@ -3,6 +3,7 @@
 namespace BeesBlogModule;
 
 use BeesBlog;
+use Context;
 use Configuration;
 use Db;
 use DbQuery;
@@ -91,6 +92,7 @@ class BlogPostEntityType extends EntityTypeBase
             ->select('DISTINCT bl.id_bees_blog_post')
             ->from('bees_blog_post_lang', 'bl')
             ->innerJoin('bees_blog_post', 'b', '(b.id_bees_blog_post = bl.id_bees_blog_post)')
+            ->join(Shop::addSqlAssociation('bees_blog_post', 'b'))
             ->innerJoin('lang', 'l', '(l.id_lang = bl.id_lang AND l.active)')
             ->where('b.active')
             ->where('bl.lang_active');
@@ -159,9 +161,10 @@ class BlogPostEntityType extends EntityTypeBase
     {
         $conn = Db::getInstance();
         $blogposts = $conn->getArray((new DbQuery())
-            ->select('DISTINCT bl.id_bees_blog_post, bl.id_lang, bl.link_rewrite')
+            ->select('DISTINCT bl.id_bees_blog_post, bl.id_lang, bl.link_rewrite, bees_blog_post_shop.id_shop')
             ->from('bees_blog_post_lang', 'bl')
             ->innerJoin('bees_blog_post', 'b', '(b.id_bees_blog_post = bl.id_bees_blog_post)')
+            ->join(Shop::addSqlAssociation('bees_blog_post', 'b'))
             ->innerJoin('lang', 'l', '(l.id_lang = bl.id_lang AND l.active)')
             ->where('b.active')
             ->where('bl.lang_active')
@@ -169,16 +172,13 @@ class BlogPostEntityType extends EntityTypeBase
         );
 
         $mapping = [];
-        $shops = Shop::getShops(true, null, true);
-
         foreach ($blogposts as $row) {
-            foreach ($shops as $shopId) {
-                $langId = (int)$row['id_lang'];
-                $blogPostId = (int)$row['id_bees_blog_post'];
-                $linkRewrite = (string)$row['link_rewrite'];
-                $url = BeesBlog::getBeesBlogLink('beesblog_post', ['blog_rewrite' => $linkRewrite], (int)$shopId, $langId);
-                $mapping[$url] = $blogPostId;
-            }
+            $shopId = (int)$row['id_shop'];
+            $langId = (int)$row['id_lang'];
+            $blogPostId = (int)$row['id_bees_blog_post'];
+            $linkRewrite = (string)$row['link_rewrite'];
+            $url = BeesBlog::getBeesBlogLink('beesblog_post', ['blog_rewrite' => $linkRewrite], $shopId, $langId);
+            $mapping[$url] = $blogPostId;
         }
 
         return $mapping;
@@ -208,7 +208,8 @@ class BlogPostEntityType extends EntityTypeBase
      */
     protected function loadEntity(int $entityId)
     {
-        $blogpost = new BeesBlogPost($entityId);
+        $context = Context::getContext();
+        $blogpost = new BeesBlogPost($entityId, $context->language->id, $context->shop->id);
         if (Validate::isLoadedObject($blogpost)) {
             return $blogpost;
         }

--- a/controllers/admin/AdminBeesBlogCategoryController.php
+++ b/controllers/admin/AdminBeesBlogCategoryController.php
@@ -53,8 +53,8 @@ class AdminBeesBlogCategoryController extends ModuleAdminController
         // Retrieve the context from a static context, just because
         $this->context = Context::getContext();
 
-        // Only display this page in single store context
-        $this->multishop_context = Shop::CONTEXT_SHOP;
+        // Allow all multishop contexts
+        $this->multishop_context = Shop::CONTEXT_ALL;
 
         // Make sure that when we save the `BeesBlogCategory` ObjectModel, the `_shop` table is set, too (primary => id_shop relation)
         Shop::addTableAssociation(BeesBlogCategory::TABLE, ['type' => 'shop']);
@@ -99,6 +99,11 @@ class AdminBeesBlogCategoryController extends ModuleAdminController
                 'orderby' => false,
             ],
         ];
+
+        $this->_join = Shop::addSqlAssociation($this->table, 'a');
+        if (Shop::isFeatureActive() && Shop::getContext() != Shop::CONTEXT_SHOP) {
+            $this->_group = 'GROUP BY a.`'.BeesBlogCategory::PRIMARY.'`';
+        }
 
         // With all this info set, it's about time to call the parent constructor
         parent::__construct();
@@ -233,9 +238,20 @@ class AdminBeesBlogCategoryController extends ModuleAdminController
             ],
         ];
 
+        if (Shop::isFeatureActive() && Shop::getContext() != Shop::CONTEXT_SHOP) {
+            $this->fields_form['input'][] = [
+                'type'  => 'shop',
+                'label' => $this->l('Shop association'),
+            ];
+        }
+
         $this->fields_value = [
             'category_image' => $imageUrl
         ];
+
+        if (Shop::isFeatureActive() && $id) {
+            $this->fields_value['shop_association'] = $this->getAssociatedShopIdsForForm($id);
+        }
 
         Media::addJsDef(['PS_ALLOW_ACCENTED_CHARS_URL' => (int) Configuration::get('PS_ALLOW_ACCENTED_CHARS_URL')]);
 
@@ -458,7 +474,7 @@ class AdminBeesBlogCategoryController extends ModuleAdminController
         if (!$blogCategory->position) {
             $blogCategory->position = 0;
         }
-        $blogCategory->id_shop = (int) Context::getContext()->shop->id;
+        $this->applyShopAssociation($blogCategory);
         foreach (Language::getLanguages(false, false, true) as $idLang) {
             if (!$blogCategory->link_rewrite[$idLang]) {
                 $blogCategory->link_rewrite[$idLang] = Tools::link_rewrite($blogCategory->title[$idLang]);
@@ -545,7 +561,7 @@ class AdminBeesBlogCategoryController extends ModuleAdminController
         if (!$blogCategory->position) {
             $blogCategory->position = 0;
         }
-        $blogCategory->id_shop = (int) Context::getContext()->shop->id;
+        $this->applyShopAssociation($blogCategory);
 
         $this->processImage($_FILES, $blogCategory->id);
 
@@ -646,11 +662,66 @@ class AdminBeesBlogCategoryController extends ModuleAdminController
     {
         $id = (int)Tools::getValue(BeesBlogCategory::PRIMARY);
         if ($id) {
-            $category = new BeesBlogCategory($id, $this->context->language->id);
+            $category = new BeesBlogCategory($id, $this->context->language->id, $this->context->shop->id);
             if (Validate::isLoadedObject($category)) {
                 return $category->link;
             }
         }
         return null;
+    }
+
+    /**
+     * @param BeesBlogCategory $blogCategory
+     */
+    protected function applyShopAssociation(BeesBlogCategory $blogCategory)
+    {
+        if (!Shop::isFeatureActive()) {
+            $blogCategory->id_shop = (int) $this->context->shop->id;
+            return;
+        }
+
+        $shopIds = $this->getAssociatedShopIds();
+        if ($shopIds) {
+            $blogCategory->id_shop_list = $shopIds;
+            if (Shop::getContext() === Shop::CONTEXT_SHOP) {
+                $blogCategory->id_shop = (int) $this->context->shop->id;
+            }
+        }
+    }
+
+    /**
+     * @return int[]
+     */
+    protected function getAssociatedShopIds()
+    {
+        if (!Shop::isFeatureActive()) {
+            return [];
+        }
+
+        if (Shop::getContext() === Shop::CONTEXT_SHOP) {
+            return [(int) $this->context->shop->id];
+        }
+
+        $selected = Tools::getValue('checkBoxShopAsso_'.$this->table);
+        if (is_array($selected) && $selected) {
+            return array_map('intval', $selected);
+        }
+
+        return Shop::getContextListShopID();
+    }
+
+    /**
+     * @param int $id
+     *
+     * @return int[]
+     */
+    protected function getAssociatedShopIdsForForm($id)
+    {
+        $query = new DbQuery();
+        $query->select('id_shop');
+        $query->from(BeesBlogCategory::SHOP_TABLE);
+        $query->where('`'.BeesBlogCategory::PRIMARY.'` = '.(int) $id);
+
+        return array_map('intval', array_column(Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($query), 'id_shop'));
     }
 }

--- a/controllers/admin/AdminBeesBlogPostController.php
+++ b/controllers/admin/AdminBeesBlogPostController.php
@@ -57,8 +57,8 @@ class AdminBeesBlogPostController extends ModuleAdminController
         // Retrieve the context from a static context, just because
         $this->context = Context::getContext();
 
-        // Only display this page in single store context
-        $this->multishop_context = Shop::CONTEXT_SHOP;
+        // Allow all multishop contexts
+        $this->multishop_context = Shop::CONTEXT_ALL;
 
         // Make sure that when we save the `BeesBlogCategory` ObjectModel, the `_shop` table is set, too (primary => id_shop relation)
         Shop::addTableAssociation(BeesBlogPost::TABLE, ['type' => 'shop']);
@@ -126,12 +126,12 @@ class AdminBeesBlogPostController extends ModuleAdminController
         ];
 
         // Set some default HelperList sortings
-        $this->_join = 'LEFT JOIN '._DB_PREFIX_.'bees_blog_post_shop sbs ON a.id_bees_blog_post = sbs.id_bees_blog_post AND sbs.id_shop IN('.implode(',', Shop::getContextListShopID()).')';
+        $this->_join = Shop::addSqlAssociation($this->table, 'a');
         $this->_defaultOrderBy = 'a.id_bees_blog_post';
         $this->_defaultOrderWay = 'DESC';
 
         if (Shop::isFeatureActive() && Shop::getContext() != Shop::CONTEXT_SHOP) {
-            $this->_group = 'GROUP BY a.bees_blog_post';
+            $this->_group = 'GROUP BY a.`'.BeesBlogPost::PRIMARY.'`';
         }
 
         // Check if there are any categories available
@@ -470,10 +470,21 @@ class AdminBeesBlogPostController extends ModuleAdminController
             ],
         ];
 
+        if (Shop::isFeatureActive() && Shop::getContext() != Shop::CONTEXT_SHOP) {
+            $this->fields_form['input'][] = [
+                'type'  => 'shop',
+                'label' => $this->l('Shop association'),
+            ];
+        }
+
         $this->fields_value = [
             'post_image' => $imageUrl,
             'products' => $products,
         ];
+
+        if (Shop::isFeatureActive() && $id) {
+            $this->fields_value['shop_association'] = $this->getAssociatedShopIdsForForm($id);
+        }
 
         foreach (Language::getLanguages(true) as $language) {
             $this->fields_value['lang_active_'.(int) $language['id_lang']] = (bool) BeesBlogPost::getLangActive(Tools::getValue(BeesBlogPost::PRIMARY), $language['id_lang']);
@@ -655,7 +666,7 @@ class AdminBeesBlogPostController extends ModuleAdminController
 
         $blogPost->id_employee = $this->context->employee->id;
         $blogPost->viewed = 0;
-        $blogPost->id_shop = (int) Context::getContext()->shop->id;
+        $this->applyShopAssociation($blogPost);
 
         if ($blogPost->add()) {
             $this->processImage($_FILES, $blogPost->id);
@@ -710,7 +721,7 @@ class AdminBeesBlogPostController extends ModuleAdminController
         $blogPost->lang_active = [];
         $this->copyFromPost($blogPost, $this->table);
 
-        $blogPost->id_shop = (int) Context::getContext()->shop->id;
+        $this->applyShopAssociation($blogPost);
         $this->processImage($_FILES, $blogPost->id);
         $this->processProducts($blogPost->id);
         if ($blogPost->update()) {
@@ -852,9 +863,64 @@ class AdminBeesBlogPostController extends ModuleAdminController
     {
         $id = (int)Tools::getValue(BeesBlogPost::PRIMARY);
         if ($id) {
-            $post = new BeesBlogPost($id, $this->context->language->id);
+            $post = new BeesBlogPost($id, $this->context->language->id, $this->context->shop->id);
             return $post->link;
         }
         return null;
+    }
+
+    /**
+     * @param BeesBlogPost $blogPost
+     */
+    protected function applyShopAssociation(BeesBlogPost $blogPost)
+    {
+        if (!Shop::isFeatureActive()) {
+            $blogPost->id_shop = (int) $this->context->shop->id;
+            return;
+        }
+
+        $shopIds = $this->getAssociatedShopIds();
+        if ($shopIds) {
+            $blogPost->id_shop_list = $shopIds;
+            if (Shop::getContext() === Shop::CONTEXT_SHOP) {
+                $blogPost->id_shop = (int) $this->context->shop->id;
+            }
+        }
+    }
+
+    /**
+     * @return int[]
+     */
+    protected function getAssociatedShopIds()
+    {
+        if (!Shop::isFeatureActive()) {
+            return [];
+        }
+
+        if (Shop::getContext() === Shop::CONTEXT_SHOP) {
+            return [(int) $this->context->shop->id];
+        }
+
+        $selected = Tools::getValue('checkBoxShopAsso_'.$this->table);
+        if (is_array($selected) && $selected) {
+            return array_map('intval', $selected);
+        }
+
+        return Shop::getContextListShopID();
+    }
+
+    /**
+     * @param int $id
+     *
+     * @return int[]
+     */
+    protected function getAssociatedShopIdsForForm($id)
+    {
+        $query = new DbQuery();
+        $query->select('id_shop');
+        $query->from(BeesBlogPost::SHOP_TABLE);
+        $query->where('`'.BeesBlogPost::PRIMARY.'` = '.(int) $id);
+
+        return array_map('intval', array_column(Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($query), 'id_shop'));
     }
 }

--- a/controllers/front/category.php
+++ b/controllers/front/category.php
@@ -112,7 +112,7 @@ class BeesBlogCategoryModuleFrontController extends ModuleFrontController
     {
         $categoryId = (int)$categoryId;
         if ($categoryId) {
-            $category = new BeesBlogCategory($categoryId, $this->context->language->id);
+            $category = new BeesBlogCategory($categoryId, $this->context->language->id, $this->context->shop->id);
             if (Validate::isLoadedObject($category) && $category->active) {
                 return $category;
             }

--- a/controllers/front/post.php
+++ b/controllers/front/post.php
@@ -133,7 +133,7 @@ class BeesBlogPostModuleFrontController extends ModuleFrontController
         if (is_null($this->blogPost)) {
             $postId = $this->getBeesBlogPostId();
             if ($postId) {
-                $blogPost = new BeesBlogPost($postId, $this->context->language->id);
+                $blogPost = new BeesBlogPost($postId, $this->context->language->id, $this->context->shop->id);
                 if (Validate::isLoadedObject($blogPost) && $blogPost->active && $blogPost->lang_active) {
                     $blogPost->content = BeesBlog::processText($blogPost->content);
                     $this->blogPost = $blogPost;

--- a/upgrade/upgrade-1.7.1.php
+++ b/upgrade/upgrade-1.7.1.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Copyright (C) 2017-2024 thirty bees
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@thirtybees.com so we can send you a copy immediately.
+ *
+ * @author    thirty bees <modules@thirtybees.com>
+ * @copyright 2017-2024 thirty bees
+ * @license   Academic Free License (AFL 3.0)
+ */
+
+if (!defined('_TB_VERSION_')) {
+    exit;
+}
+
+/**
+ * @return bool
+ * @throws PrestaShopDatabaseException
+ */
+function upgrade_module_1_7_1()
+{
+    $db = Db::getInstance();
+    $result = true;
+
+    $result &= $db->execute(
+        'CREATE TABLE IF NOT EXISTS `'._DB_PREFIX_.'bees_blog_post_shop` (
+            `id_bees_blog_post` INT(11) UNSIGNED NOT NULL,
+            `id_shop` INT(11) UNSIGNED NOT NULL,
+            PRIMARY KEY (`id_bees_blog_post`, `id_shop`),
+            KEY `id_shop` (`id_shop`)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci'
+    );
+
+    $result &= $db->execute(
+        'CREATE TABLE IF NOT EXISTS `'._DB_PREFIX_.'bees_blog_category_shop` (
+            `id_bees_blog_category` INT(11) UNSIGNED NOT NULL,
+            `id_shop` INT(11) UNSIGNED NOT NULL,
+            PRIMARY KEY (`id_bees_blog_category`, `id_shop`),
+            KEY `id_shop` (`id_shop`)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci'
+    );
+
+    $result &= $db->execute(
+        'INSERT INTO `'._DB_PREFIX_.'bees_blog_post_shop` (`id_bees_blog_post`, `id_shop`)
+         SELECT p.`id_bees_blog_post`, s.`id_shop`
+         FROM `'._DB_PREFIX_.'bees_blog_post` p
+         CROSS JOIN `'._DB_PREFIX_.'shop` s
+         LEFT JOIN `'._DB_PREFIX_.'bees_blog_post_shop` ps
+           ON (ps.`id_bees_blog_post` = p.`id_bees_blog_post` AND ps.`id_shop` = s.`id_shop`)
+         WHERE ps.`id_bees_blog_post` IS NULL'
+    );
+
+    $result &= $db->execute(
+        'INSERT INTO `'._DB_PREFIX_.'bees_blog_category_shop` (`id_bees_blog_category`, `id_shop`)
+         SELECT c.`id_bees_blog_category`, s.`id_shop`
+         FROM `'._DB_PREFIX_.'bees_blog_category` c
+         CROSS JOIN `'._DB_PREFIX_.'shop` s
+         LEFT JOIN `'._DB_PREFIX_.'bees_blog_category_shop` cs
+           ON (cs.`id_bees_blog_category` = c.`id_bees_blog_category` AND cs.`id_shop` = s.`id_shop`)
+         WHERE cs.`id_bees_blog_category` IS NULL'
+    );
+
+    $configRows = $db->executeS(
+        'SELECT `name`, `value`
+         FROM `'._DB_PREFIX_.'configuration`
+         WHERE `name` LIKE "BEESBLOG\\_%" AND `id_shop` IS NULL AND `id_shop_group` IS NULL'
+    );
+
+    if ($configRows) {
+        $now = date('Y-m-d H:i:s');
+        foreach (Shop::getShops(true, null, true) as $shopId) {
+            foreach ($configRows as $config) {
+                $name = (string) $config['name'];
+                $value = (string) $config['value'];
+                $exists = $db->getValue(
+                    'SELECT `id_configuration`
+                     FROM `'._DB_PREFIX_.'configuration`
+                     WHERE `name` = "'.pSQL($name).'"
+                       AND `id_shop` = '.(int) $shopId.'
+                       AND `id_shop_group` IS NULL'
+                );
+                if (!$exists) {
+                    $result &= $db->insert('configuration', [
+                        'name' => pSQL($name),
+                        'value' => pSQL($value, true),
+                        'date_add' => $now,
+                        'date_upd' => $now,
+                        'id_shop_group' => null,
+                        'id_shop' => (int) $shopId,
+                    ]);
+                }
+            }
+        }
+    }
+
+    return (bool) $result;
+}


### PR DESCRIPTION
### Motivation

- Ensure blog posts and categories are correctly scoped to shops so front-end listings, sitemaps, shortcodes and admin UI respect multistore associations. 
- Provide a safe upgrade path to add `_shop` association tables and migrate existing global configuration into per-shop settings.

### Description

- Added shop association tables and lifecycle helpers by creating `upgrade/upgrade-1.7.1.php` to create `bees_blog_post_shop` and `bees_blog_category_shop`, backfill existing posts/categories (via `CROSS JOIN ps_shop`) and migrate `BEESBLOG_*` configuration rows to per-shop entries. 
- Updated data models to be shop-aware by adding `Shop::addSqlAssociation` joins and shop-shop-table creation/drop helpers in `classes/BeesBlogPost.php` and `classes/BeesBlogCategory.php`, plus new query builders (`buildPostsQuery`, `hydratePostsFromRows`, etc.) to fetch only items available in the current shop context. 
- Updated front-end and integration points so objects are loaded in a shop context and sitemap/shortcode URL mapping are shop-aware by changing `controllers/front/post.php`, `controllers/front/category.php`, `beesblog.php` (sitemap hook) and `classes/shortcode/BlogPostEntityType.php` to use shop-aware queries and pass shop IDs when constructing `BeesBlogPost`/`BeesBlogCategory`. 
- Made admin controllers multishop-capable with shop association UI and persistence by changing `controllers/admin/AdminBeesBlogPostController.php` and `controllers/admin/AdminBeesBlogCategoryController.php` to use `Shop::addSqlAssociation`, allow `Shop::CONTEXT_ALL`, add `shop` inputs to forms, and implement `applyShopAssociation` / `getAssociatedShopIdsForForm` to persist associations; also bumped module version in `beesblog.php` to `1.7.1`.

### Testing

- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a9cc490bc832d8efc450748bf6424)