### PR TITLE
Make beesblog multistore-aware (posts & categories)

### DIFF
--- a/beesblog.php
+++ b/beesblog.php
@@ -87,7 +87,7 @@ class BeesBlog extends Module
     {
         $this->name = 'beesblog';
         $this->tab = 'front_office_features';
-        $this->version = '1.7.0';
+        $this->version = '1.7.1';
         $this->author = 'thirty bees';
         $this->tb_min_version = '1.0.0';
         $this->tb_versions_compliancy = '> 1.0.0';
@@ -486,6 +486,7 @@ class BeesBlog extends Module
 
         // Blog posts
         $results = (new PrestaShopCollection('BeesBlogModule\\BeesBlogPost', $langId))
+            ->sqlJoin(Shop::addSqlAssociation(BeesBlogPost::TABLE, 'a'))
             ->where('active', '=', 1)
             ->getResults();
         if ($results) {
@@ -504,6 +505,7 @@ class BeesBlog extends Module
 
         // Categories
         $results = (new PrestaShopCollection('BeesBlogModule\\BeesBlogCategory', $langId))
+            ->sqlJoin(Shop::addSqlAssociation(BeesBlogCategory::TABLE, 'a'))
             ->where('active', '=', 1)
             ->getResults();
 

--- a/classes/BeesBlogCategory.php
+++ b/classes/BeesBlogCategory.php
@@ -20,13 +20,14 @@
 namespace BeesBlogModule;
 
 use BeesBlog;
-use PrestaShopCollection as Collection;
 use Context;
 use Db;
 use DbQuery;
 use ObjectModel;
 use PrestaShopDatabaseException;
 use PrestaShopException;
+use PrestaShopCollection as Collection;
+use Shop;
 
 if (!defined('_TB_VERSION_')) {
     exit;
@@ -207,6 +208,7 @@ class BeesBlogCategory extends ObjectModel
         $postCollection->setPageSize($limit);
         $postCollection->setPageNumber($page);
         $postCollection->orderBy('published', 'desc');
+        $postCollection->sqlJoin(Shop::addSqlAssociation(BeesBlogPost::TABLE, 'a'));
         $postCollection->where('published', '<=', date('Y-m-d H:i:s'));
         $postCollection->where('id_category', '=', $this->id);
         $postCollection->where('active', '=', '1');
@@ -240,6 +242,7 @@ class BeesBlogCategory extends ObjectModel
         $categoryCollection = new Collection('BeesBlogModule\\BeesBlogCategory', $idLang);
         $categoryCollection->setPageSize($limit);
         $categoryCollection->setPageNumber($page);
+        $categoryCollection->sqlJoin(Shop::addSqlAssociation(static::TABLE, 'a'));
 
         if ($count) {
             return $categoryCollection->count();
@@ -264,6 +267,7 @@ class BeesBlogCategory extends ObjectModel
         }
 
         $categoryCollection = new Collection('BeesBlogModule\\BeesBlogCategory', $idLang);
+        $categoryCollection->sqlJoin(Shop::addSqlAssociation(static::TABLE, 'a'));
         $categoryCollection->where('id_parent', '=', 0);
 
         /** @var BeesBlogCategory|false $ret */
@@ -297,9 +301,11 @@ class BeesBlogCategory extends ObjectModel
         $sql->select('sbc.`'.static::PRIMARY.'`');
         $sql->from(static::TABLE, 'sbc');
         $sql->innerJoin(static::LANG_TABLE, 'sbcl', 'sbc.`'.static::PRIMARY.'` = sbcl.`'.static::PRIMARY.'`');
-        $sql->innerJoin(static::SHOP_TABLE, 'sbcs', 'sbc.`'.static::PRIMARY.'` = sbcs.`'.static::PRIMARY.'`');
+        $sql->join(Shop::addSqlAssociation(static::TABLE, 'sbc'));
+        if ($idShop) {
+            $sql->where('sbc_shop.`id_shop` = '.(int) $idShop);
+        }
         $sql->where('sbcl.`id_lang` = '.(int) $idLang);
-        $sql->where('sbcs.`id_shop` = '.(int) $idShop);
         $sql->where('sbc.`active` = '.(int) $active);
         $sql->where('sbcl.`link_rewrite` = \''.pSQL($rewrite).'\'');
 
@@ -373,16 +379,16 @@ class BeesBlogCategory extends ObjectModel
      */
     public static function getNameById($id, $id_lang = null)
     {
-        if (empty($idLang)) {
-            $idLang = (int) Context::getContext()->language->id;
+        if (empty($id_lang)) {
+            $id_lang = (int) Context::getContext()->language->id;
         }
 
         $sql = new DbQuery();
         $sql->select('sbcl.`title`');
         $sql->from(static::TABLE, 'sbc');
         $sql->innerJoin(static::LANG_TABLE, 'sbcl', 'sbc.`'.static::PRIMARY.'` = sbcl.`'.static::PRIMARY.'`');
-        $sql->innerJoin(static::SHOP_TABLE, 'sbcs', 'sbc.`'.static::PRIMARY.'` = sbcs.`'.static::PRIMARY.'`');
-        $sql->where('sbcl.`id_lang` = '.(int) $idLang);
+        $sql->join(Shop::addSqlAssociation(static::TABLE, 'sbc'));
+        $sql->where('sbcl.`id_lang` = '.(int) $id_lang);
         $sql->where('sbcl.`'.static::PRIMARY.'` = \''.pSQL($id).'\'');
 
         return Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql);

--- a/classes/BeesBlogPost.php
+++ b/classes/BeesBlogPost.php
@@ -21,13 +21,14 @@ namespace BeesBlogModule;
 
 use BeesBlog;
 use Employee;
-use PrestaShopCollection as Collection;
 use Context;
 use Db;
 use DbQuery;
 use ObjectModel;
 use PrestaShopDatabaseException;
 use PrestaShopException;
+use PrestaShopCollection as Collection;
+use Shop;
 
 if (!defined('_TB_VERSION_')) {
     exit;
@@ -265,6 +266,7 @@ class BeesBlogPost extends ObjectModel
         $postCollection->setPageSize($limit);
         $postCollection->setPageNumber($page);
         $postCollection->orderBy('published', 'desc');
+        $postCollection->sqlJoin(Shop::addSqlAssociation(static::TABLE, 'a'));
         $postCollection->where('published', '<=', date('Y-m-d H:i:s'));
         $postCollection->where('active', '=', '1');
         $postCollection->sqlWhere('lang_active = \'1\'');
@@ -313,6 +315,7 @@ class BeesBlogPost extends ObjectModel
         $postCollection->setPageSize($limit);
         $postCollection->setPageNumber($page);
         $postCollection->orderBy('viewed', 'desc');
+        $postCollection->sqlJoin(Shop::addSqlAssociation(static::TABLE, 'a'));
         $postCollection->where('published', '<=', date('Y-m-d H:i:s'));
         $postCollection->sqlWhere('lang_active = \'1\'');
 
@@ -368,7 +371,8 @@ class BeesBlogPost extends ObjectModel
     {
         $sql = new DbQuery();
         $sql->select('`'.self::PRIMARY.'`');
-        $sql->from(self::TABLE);
+        $sql->from(self::TABLE, 'sbp');
+        $sql->join(Shop::addSqlAssociation(self::TABLE, 'sbp'));
 
         return Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql);
     }
@@ -389,15 +393,16 @@ class BeesBlogPost extends ObjectModel
             $idLang = (int) Context::getContext()->language->id;
         }
         $idShop = (int) Context::getContext()->shop->id;
-
         $sql = new DbQuery();
         $sql->select('sbp.`link_rewrite`');
         $sql->from(self::TABLE, 'sbp');
         $sql->innerJoin(self::LANG_TABLE, 'sbpl', 'sbp.`'.self::PRIMARY.'` = sbpl.`'.self::PRIMARY.'`');
-        $sql->innerJoin(self::SHOP_TABLE, 'sbps', 'sbp.`'.self::PRIMARY.'` = sbps.`'.self::PRIMARY.'`');
+        $sql->join(Shop::addSqlAssociation(self::TABLE, 'sbp'));
+        if ($idShop) {
+            $sql->where('sbp_shop.`id_shop` = '.(int) $idShop);
+        }
         $sql->where('sbpl.`id_lang` = '.(int) $idLang);
         $sql->where('sbpl.`lang_active` = 1');
-        $sql->where('sbps.`id_shop` = '.(int) $idShop);
         $sql->where('sbp.`active` = 1');
         $sql->where('sbp.`'.self::PRIMARY.'` = '.(int) $idPost);
 
@@ -431,9 +436,11 @@ class BeesBlogPost extends ObjectModel
         $sql->select('sbp.`'.self::PRIMARY.'`');
         $sql->from(self::TABLE, 'sbp');
         $sql->innerJoin(self::LANG_TABLE, 'sbpl', 'sbp.`'.self::PRIMARY.'` = sbpl.`'.self::PRIMARY.'`');
-        $sql->innerJoin(self::SHOP_TABLE, 'sbps', 'sbp.`'.self::PRIMARY.'` = sbps.`'.self::PRIMARY.'`');
+        $sql->join(Shop::addSqlAssociation(self::TABLE, 'sbp'));
+        if ($idShop) {
+            $sql->where('sbp_shop.`id_shop` = '.(int) $idShop);
+        }
         $sql->where('sbpl.`id_lang` = '.(int) $idLang);
-        $sql->where('sbps.`id_shop` = '.(int) $idShop);
         $sql->where('sbp.`active` = '.(int) $active);
         $sql->where('sbpl.`lang_active`');
         $sql->where('sbpl.`link_rewrite` = \''.pSQL($rewrite).'\'');

--- a/classes/shortcode/BlogPostEntityType.php
+++ b/classes/shortcode/BlogPostEntityType.php
@@ -91,6 +91,7 @@ class BlogPostEntityType extends EntityTypeBase
             ->select('DISTINCT bl.id_bees_blog_post')
             ->from('bees_blog_post_lang', 'bl')
             ->innerJoin('bees_blog_post', 'b', '(b.id_bees_blog_post = bl.id_bees_blog_post)')
+            ->join(Shop::addSqlAssociation('bees_blog_post', 'b'))
             ->innerJoin('lang', 'l', '(l.id_lang = bl.id_lang AND l.active)')
             ->where('b.active')
             ->where('bl.lang_active');
@@ -159,26 +160,26 @@ class BlogPostEntityType extends EntityTypeBase
     {
         $conn = Db::getInstance();
         $blogposts = $conn->getArray((new DbQuery())
-            ->select('DISTINCT bl.id_bees_blog_post, bl.id_lang, bl.link_rewrite')
+            ->select('DISTINCT bl.id_bees_blog_post, bl.id_lang, bl.link_rewrite, bs.id_shop')
             ->from('bees_blog_post_lang', 'bl')
             ->innerJoin('bees_blog_post', 'b', '(b.id_bees_blog_post = bl.id_bees_blog_post)')
+            ->innerJoin('bees_blog_post_shop', 'bs', 'bs.id_bees_blog_post = b.id_bees_blog_post')
             ->innerJoin('lang', 'l', '(l.id_lang = bl.id_lang AND l.active)')
             ->where('b.active')
             ->where('bl.lang_active')
+            ->where(Shop::addSqlRestriction(false, 'bs'))
             ->orderBy('bl.id_bees_blog_post, bl.id_lang')
         );
 
         $mapping = [];
-        $shops = Shop::getShops(true, null, true);
 
         foreach ($blogposts as $row) {
-            foreach ($shops as $shopId) {
-                $langId = (int)$row['id_lang'];
-                $blogPostId = (int)$row['id_bees_blog_post'];
-                $linkRewrite = (string)$row['link_rewrite'];
-                $url = BeesBlog::getBeesBlogLink('beesblog_post', ['blog_rewrite' => $linkRewrite], (int)$shopId, $langId);
-                $mapping[$url] = $blogPostId;
-            }
+            $langId = (int)$row['id_lang'];
+            $blogPostId = (int)$row['id_bees_blog_post'];
+            $linkRewrite = (string)$row['link_rewrite'];
+            $shopId = (int)$row['id_shop'];
+            $url = BeesBlog::getBeesBlogLink('beesblog_post', ['blog_rewrite' => $linkRewrite], $shopId, $langId);
+            $mapping[$url] = $blogPostId;
         }
 
         return $mapping;

--- a/controllers/admin/AdminBeesBlogCategoryController.php
+++ b/controllers/admin/AdminBeesBlogCategoryController.php
@@ -53,8 +53,8 @@ class AdminBeesBlogCategoryController extends ModuleAdminController
         // Retrieve the context from a static context, just because
         $this->context = Context::getContext();
 
-        // Only display this page in single store context
-        $this->multishop_context = Shop::CONTEXT_SHOP;
+        // Allow all shop contexts for association management
+        $this->multishop_context = Shop::CONTEXT_ALL;
 
         // Make sure that when we save the `BeesBlogCategory` ObjectModel, the `_shop` table is set, too (primary => id_shop relation)
         Shop::addTableAssociation(BeesBlogCategory::TABLE, ['type' => 'shop']);
@@ -99,6 +99,11 @@ class AdminBeesBlogCategoryController extends ModuleAdminController
                 'orderby' => false,
             ],
         ];
+
+        $this->_join = Shop::addSqlAssociation(BeesBlogCategory::TABLE, 'a');
+        if (Shop::isFeatureActive() && Shop::getContext() != Shop::CONTEXT_SHOP) {
+            $this->_group = 'GROUP BY a.id_bees_blog_category';
+        }
 
         // With all this info set, it's about time to call the parent constructor
         parent::__construct();
@@ -236,6 +241,15 @@ class AdminBeesBlogCategoryController extends ModuleAdminController
         $this->fields_value = [
             'category_image' => $imageUrl
         ];
+
+        if (Shop::isFeatureActive() && Shop::getContext() != Shop::CONTEXT_SHOP) {
+            $this->fields_form['input'][] = [
+                'type'  => 'shop',
+                'label' => $this->l('Shop association'),
+                'name'  => 'checkBoxShopAsso',
+            ];
+            $this->fields_value['checkBoxShopAsso'] = $this->getAssociatedShopIds($id);
+        }
 
         Media::addJsDef(['PS_ALLOW_ACCENTED_CHARS_URL' => (int) Configuration::get('PS_ALLOW_ACCENTED_CHARS_URL')]);
 
@@ -458,7 +472,9 @@ class AdminBeesBlogCategoryController extends ModuleAdminController
         if (!$blogCategory->position) {
             $blogCategory->position = 0;
         }
-        $blogCategory->id_shop = (int) Context::getContext()->shop->id;
+        $shopIds = $this->getSelectedShopIds();
+        $blogCategory->id_shop_list = $shopIds;
+        $blogCategory->id_shop = (int) reset($shopIds);
         foreach (Language::getLanguages(false, false, true) as $idLang) {
             if (!$blogCategory->link_rewrite[$idLang]) {
                 $blogCategory->link_rewrite[$idLang] = Tools::link_rewrite($blogCategory->title[$idLang]);
@@ -468,6 +484,7 @@ class AdminBeesBlogCategoryController extends ModuleAdminController
         // TODO: check if link_rewrite is unique
         if ($blogCategory->add()) {
             $this->processImage($_FILES, $blogCategory->id);
+            $this->updateShopAssociation($blogCategory->id, $shopIds);
             $this->confirmations[] = $this->l('Successfully added a new category');
 
             if (Tools::isSubmit('submitAdd'.$this->table.'AndStay')) {
@@ -545,13 +562,16 @@ class AdminBeesBlogCategoryController extends ModuleAdminController
         if (!$blogCategory->position) {
             $blogCategory->position = 0;
         }
-        $blogCategory->id_shop = (int) Context::getContext()->shop->id;
+        $shopIds = $this->getSelectedShopIds();
+        $blogCategory->id_shop_list = $shopIds;
+        $blogCategory->id_shop = (int) reset($shopIds);
 
         $this->processImage($_FILES, $blogCategory->id);
 
         // TODO: check if link_rewrite is unique
 
         if ($blogCategory->update()) {
+            $this->updateShopAssociation($blogCategory->id, $shopIds);
             $this->confirmations[] = $this->l('Successfully updated the category');
 
             if (Tools::isSubmit('submitAdd'.$this->table.'AndStay')) {
@@ -646,11 +666,77 @@ class AdminBeesBlogCategoryController extends ModuleAdminController
     {
         $id = (int)Tools::getValue(BeesBlogCategory::PRIMARY);
         if ($id) {
-            $category = new BeesBlogCategory($id, $this->context->language->id);
+            $category = new BeesBlogCategory($id, $this->context->language->id, $this->context->shop->id);
             if (Validate::isLoadedObject($category)) {
                 return $category->link;
             }
         }
         return null;
+    }
+
+    /**
+     * @param int $id
+     *
+     * @return int[]
+     */
+    protected function getAssociatedShopIds($id)
+    {
+        $id = (int) $id;
+        if (!$id) {
+            return Shop::getContextListShopID();
+        }
+        $rows = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS(
+            'SELECT id_shop FROM '._DB_PREFIX_.BeesBlogCategory::SHOP_TABLE.' WHERE '.BeesBlogCategory::PRIMARY.' = '.$id
+        );
+        if (!$rows) {
+            return Shop::getContextListShopID();
+        }
+        return array_map('intval', array_column($rows, 'id_shop'));
+    }
+
+    /**
+     * @return int[]
+     */
+    protected function getSelectedShopIds()
+    {
+        if (!Shop::isFeatureActive()) {
+            return [(int) $this->context->shop->id];
+        }
+
+        if (Shop::getContext() === Shop::CONTEXT_SHOP) {
+            return [(int) $this->context->shop->id];
+        }
+
+        $selected = Tools::getValue('checkBoxShopAsso');
+        if (is_array($selected) && $selected) {
+            return array_map('intval', $selected);
+        }
+
+        return Shop::getContextListShopID();
+    }
+
+    /**
+     * @param int $categoryId
+     * @param int[] $shopIds
+     *
+     * @return void
+     */
+    protected function updateShopAssociation($categoryId, array $shopIds)
+    {
+        $categoryId = (int) $categoryId;
+        Db::getInstance()->delete(BeesBlogCategory::SHOP_TABLE, BeesBlogCategory::PRIMARY.' = '.$categoryId);
+
+        if (!$shopIds) {
+            return;
+        }
+
+        $rows = [];
+        foreach ($shopIds as $shopId) {
+            $rows[] = [
+                BeesBlogCategory::PRIMARY => $categoryId,
+                'id_shop' => (int) $shopId,
+            ];
+        }
+        Db::getInstance()->insert(BeesBlogCategory::SHOP_TABLE, $rows);
     }
 }

--- a/controllers/admin/AdminBeesBlogPostController.php
+++ b/controllers/admin/AdminBeesBlogPostController.php
@@ -57,8 +57,8 @@ class AdminBeesBlogPostController extends ModuleAdminController
         // Retrieve the context from a static context, just because
         $this->context = Context::getContext();
 
-        // Only display this page in single store context
-        $this->multishop_context = Shop::CONTEXT_SHOP;
+        // Allow all shop contexts for association management
+        $this->multishop_context = Shop::CONTEXT_ALL;
 
         // Make sure that when we save the `BeesBlogCategory` ObjectModel, the `_shop` table is set, too (primary => id_shop relation)
         Shop::addTableAssociation(BeesBlogPost::TABLE, ['type' => 'shop']);
@@ -126,12 +126,12 @@ class AdminBeesBlogPostController extends ModuleAdminController
         ];
 
         // Set some default HelperList sortings
-        $this->_join = 'LEFT JOIN '._DB_PREFIX_.'bees_blog_post_shop sbs ON a.id_bees_blog_post = sbs.id_bees_blog_post AND sbs.id_shop IN('.implode(',', Shop::getContextListShopID()).')';
+        $this->_join = Shop::addSqlAssociation(BeesBlogPost::TABLE, 'a');
         $this->_defaultOrderBy = 'a.id_bees_blog_post';
         $this->_defaultOrderWay = 'DESC';
 
         if (Shop::isFeatureActive() && Shop::getContext() != Shop::CONTEXT_SHOP) {
-            $this->_group = 'GROUP BY a.bees_blog_post';
+            $this->_group = 'GROUP BY a.id_bees_blog_post';
         }
 
         // Check if there are any categories available
@@ -475,6 +475,15 @@ class AdminBeesBlogPostController extends ModuleAdminController
             'products' => $products,
         ];
 
+        if (Shop::isFeatureActive() && Shop::getContext() != Shop::CONTEXT_SHOP) {
+            $this->fields_form['input'][] = [
+                'type'  => 'shop',
+                'label' => $this->l('Shop association'),
+                'name'  => 'checkBoxShopAsso',
+            ];
+            $this->fields_value['checkBoxShopAsso'] = $this->getAssociatedShopIds($id);
+        }
+
         foreach (Language::getLanguages(true) as $language) {
             $this->fields_value['lang_active_'.(int) $language['id_lang']] = (bool) BeesBlogPost::getLangActive(Tools::getValue(BeesBlogPost::PRIMARY), $language['id_lang']);
         }
@@ -655,11 +664,14 @@ class AdminBeesBlogPostController extends ModuleAdminController
 
         $blogPost->id_employee = $this->context->employee->id;
         $blogPost->viewed = 0;
-        $blogPost->id_shop = (int) Context::getContext()->shop->id;
+        $shopIds = $this->getSelectedShopIds();
+        $blogPost->id_shop_list = $shopIds;
+        $blogPost->id_shop = (int) reset($shopIds);
 
         if ($blogPost->add()) {
             $this->processImage($_FILES, $blogPost->id);
             $this->processProducts($blogPost->id);
+            $this->updateShopAssociation($blogPost->id, $shopIds);
             $this->confirmations[] = $this->l('Successfully added post');
             if (Tools::isSubmit('submitAdd'.$this->table.'AndStay')) {
                 $this->redirect_after = static::$currentIndex.'&'.$this->identifier.'='.$blogPost->id.'&update'.$this->table.'&token='.$this->token;
@@ -710,10 +722,13 @@ class AdminBeesBlogPostController extends ModuleAdminController
         $blogPost->lang_active = [];
         $this->copyFromPost($blogPost, $this->table);
 
-        $blogPost->id_shop = (int) Context::getContext()->shop->id;
+        $shopIds = $this->getSelectedShopIds();
+        $blogPost->id_shop_list = $shopIds;
+        $blogPost->id_shop = (int) reset($shopIds);
         $this->processImage($_FILES, $blogPost->id);
         $this->processProducts($blogPost->id);
         if ($blogPost->update()) {
+            $this->updateShopAssociation($blogPost->id, $shopIds);
             $this->confirmations[] = $this->l('Successfully updated post');
             if (Tools::isSubmit('submitAdd'.$this->table.'AndStay')) {
                 $this->redirect_after = static::$currentIndex.'&'.$this->identifier.'='.$blogPost->id.'&update'.$this->table.'&token='.$this->token;
@@ -852,9 +867,75 @@ class AdminBeesBlogPostController extends ModuleAdminController
     {
         $id = (int)Tools::getValue(BeesBlogPost::PRIMARY);
         if ($id) {
-            $post = new BeesBlogPost($id, $this->context->language->id);
+            $post = new BeesBlogPost($id, $this->context->language->id, $this->context->shop->id);
             return $post->link;
         }
         return null;
+    }
+
+    /**
+     * @param int $id
+     *
+     * @return int[]
+     */
+    protected function getAssociatedShopIds($id)
+    {
+        $id = (int) $id;
+        if (!$id) {
+            return Shop::getContextListShopID();
+        }
+        $rows = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS(
+            'SELECT id_shop FROM '._DB_PREFIX_.BeesBlogPost::SHOP_TABLE.' WHERE '.BeesBlogPost::PRIMARY.' = '.$id
+        );
+        if (!$rows) {
+            return Shop::getContextListShopID();
+        }
+        return array_map('intval', array_column($rows, 'id_shop'));
+    }
+
+    /**
+     * @return int[]
+     */
+    protected function getSelectedShopIds()
+    {
+        if (!Shop::isFeatureActive()) {
+            return [(int) $this->context->shop->id];
+        }
+
+        if (Shop::getContext() === Shop::CONTEXT_SHOP) {
+            return [(int) $this->context->shop->id];
+        }
+
+        $selected = Tools::getValue('checkBoxShopAsso');
+        if (is_array($selected) && $selected) {
+            return array_map('intval', $selected);
+        }
+
+        return Shop::getContextListShopID();
+    }
+
+    /**
+     * @param int $postId
+     * @param int[] $shopIds
+     *
+     * @return void
+     */
+    protected function updateShopAssociation($postId, array $shopIds)
+    {
+        $postId = (int) $postId;
+        Db::getInstance()->delete(BeesBlogPost::SHOP_TABLE, BeesBlogPost::PRIMARY.' = '.$postId);
+
+        if (!$shopIds) {
+            return;
+        }
+
+        $rows = [];
+        foreach ($shopIds as $shopId) {
+            $rows[] = [
+                BeesBlogPost::PRIMARY => $postId,
+                'id_shop' => (int) $shopId,
+            ];
+        }
+        Db::getInstance()->insert(BeesBlogPost::SHOP_TABLE, $rows);
     }
 }

--- a/controllers/front/category.php
+++ b/controllers/front/category.php
@@ -112,7 +112,7 @@ class BeesBlogCategoryModuleFrontController extends ModuleFrontController
     {
         $categoryId = (int)$categoryId;
         if ($categoryId) {
-            $category = new BeesBlogCategory($categoryId, $this->context->language->id);
+            $category = new BeesBlogCategory($categoryId, $this->context->language->id, $this->context->shop->id);
             if (Validate::isLoadedObject($category) && $category->active) {
                 return $category;
             }

--- a/controllers/front/post.php
+++ b/controllers/front/post.php
@@ -133,7 +133,7 @@ class BeesBlogPostModuleFrontController extends ModuleFrontController
         if (is_null($this->blogPost)) {
             $postId = $this->getBeesBlogPostId();
             if ($postId) {
-                $blogPost = new BeesBlogPost($postId, $this->context->language->id);
+                $blogPost = new BeesBlogPost($postId, $this->context->language->id, $this->context->shop->id);
                 if (Validate::isLoadedObject($blogPost) && $blogPost->active && $blogPost->lang_active) {
                     $blogPost->content = BeesBlog::processText($blogPost->content);
                     $this->blogPost = $blogPost;

--- a/upgrade/upgrade-1.7.1.php
+++ b/upgrade/upgrade-1.7.1.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Copyright (C) 2017-2024 thirty bees
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@thirtybees.com so we can send you a copy immediately.
+ *
+ * @author    thirty bees <modules@thirtybees.com>
+ * @copyright 2017-2024 thirty bees
+ * @license   Academic Free License (AFL 3.0)
+ */
+
+if (!defined('_TB_VERSION_')) {
+    exit;
+}
+
+/**
+ * @return bool
+ * @throws PrestaShopDatabaseException
+ */
+function upgrade_module_1_7_1()
+{
+    $db = Db::getInstance();
+
+    $db->execute(
+        'CREATE TABLE IF NOT EXISTS `'._DB_PREFIX_.'bees_blog_post_shop` (
+            `id_bees_blog_post` INT(11) UNSIGNED NOT NULL,
+            `id_shop` INT(11) UNSIGNED NOT NULL,
+            PRIMARY KEY (`id_bees_blog_post`, `id_shop`),
+            KEY `id_shop` (`id_shop`)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci'
+    );
+
+    $db->execute(
+        'CREATE TABLE IF NOT EXISTS `'._DB_PREFIX_.'bees_blog_category_shop` (
+            `id_bees_blog_category` INT(11) UNSIGNED NOT NULL,
+            `id_shop` INT(11) UNSIGNED NOT NULL,
+            PRIMARY KEY (`id_bees_blog_category`, `id_shop`),
+            KEY `id_shop` (`id_shop`)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci'
+    );
+
+    $db->execute(
+        'INSERT IGNORE INTO `'._DB_PREFIX_.'bees_blog_post_shop` (`id_bees_blog_post`, `id_shop`)
+        SELECT p.`id_bees_blog_post`, s.`id_shop`
+        FROM `'._DB_PREFIX_.'bees_blog_post` p
+        CROSS JOIN `'._DB_PREFIX_.'shop` s'
+    );
+
+    $db->execute(
+        'INSERT IGNORE INTO `'._DB_PREFIX_.'bees_blog_category_shop` (`id_bees_blog_category`, `id_shop`)
+        SELECT c.`id_bees_blog_category`, s.`id_shop`
+        FROM `'._DB_PREFIX_.'bees_blog_category` c
+        CROSS JOIN `'._DB_PREFIX_.'shop` s'
+    );
+
+    $keys = [
+        'BEESBLOG_POSTS_PER_PAGE',
+        'BEESBLOG_SHOW_AUTHOR_STYLE',
+        'BEESBLOG_MAIN_URL_KEY',
+        'BEESBLOG_USE_HTML',
+        'BEESBLOG_ENABLE_COMMENT',
+        'BEESBLOG_SHOW_AUTHOR',
+        'BEESBLOG_SHOW_DATE',
+        'BEESBLOG_SOCIAL_SHARING',
+        'BEESBLOG_SHOW_VIEWED',
+        'BEESBLOG_SHOW_NO_IMAGE',
+        'BEESBLOG_CUSTOM_CSS',
+        'BEESBLOG_DISABLE_CATEGORY_IMAGE',
+        'BEESBLOG_META_TITLE',
+        'BEESBLOG_META_KEYWORDS',
+        'BEESBLOG_META_DESCRIPTION',
+        'BEESBLOG_DISQUS_USERNAME',
+    ];
+
+    $escapedKeys = array_map('pSQL', $keys);
+    $keysList = "'".implode("','", $escapedKeys)."'";
+
+    $db->execute(
+        'INSERT INTO `'._DB_PREFIX_.'configuration` (`id_shop_group`, `id_shop`, `name`, `value`, `date_add`, `date_upd`)
+        SELECT s.`id_shop_group`, s.`id_shop`, c.`name`, c.`value`, c.`date_add`, c.`date_upd`
+        FROM `'._DB_PREFIX_.'configuration` c
+        INNER JOIN `'._DB_PREFIX_.'shop` s ON 1=1
+        LEFT JOIN `'._DB_PREFIX_.'configuration` cs
+            ON cs.`name` = c.`name`
+            AND cs.`id_shop` = s.`id_shop`
+            AND cs.`id_shop_group` = s.`id_shop_group`
+        WHERE c.`name` IN ('.$keysList.')
+            AND c.`id_shop` IS NULL
+            AND c.`id_shop_group` IS NULL
+            AND cs.`id_configuration` IS NULL'
+    );
+
+    return true;
+}


### PR DESCRIPTION
### Motivation

- Enable true multistore support so posts and categories can be associated with shops and queries only return items for the current shop context.
- Provide a safe upgrade path that creates association tables and preserves existing content and configuration per shop.

### Description

- Added an upgrade script `upgrade/upgrade-1.7.1.php` that creates `bees_blog_post_shop` and `bees_blog_category_shop`, backfills existing posts/categories for all shops via `CROSS JOIN ps_shop`, and migrates global `BEESBLOG_*` configuration values into per-shop configuration rows when missing.
- Scoped data access to shop context by joining shop association tables and using `Shop::addSqlAssociation`/`Shop::addSqlRestriction` patterns in collections, SQL queries and sitemap generation (changes in `classes/BeesBlogPost.php`, `classes/BeesBlogCategory.php`, `beesblog.php`, and `classes/shortcode/BlogPostEntityType.php`).
- Updated front controllers to load category/post objects for the current shop (`controllers/front/category.php`, `controllers/front/post.php`).
- Updated back office controllers to support shop-aware lists and editing: changed multishop context, used `Shop::addSqlAssociation` in lists, added a native shop-association chooser to forms, and implemented `getSelectedShopIds()`, `getAssociatedShopIds()` and `updateShopAssociation()` helpers to persist `_shop` associations on add/update for posts and categories (`controllers/admin/AdminBeesBlogPostController.php`, `controllers/admin/AdminBeesBlogCategoryController.php`).
- Bumped module version to `1.7.1` in `beesblog.php` to expose the upgrade.

### Testing

- No automated tests were run as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a9cc490bc832d8efc450748bf6424)